### PR TITLE
README: Refer to documentation in Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Translation between Franca Interface Description Language (IDL) and AUTOSAR Adaptive models.
 
+## User & Developer Documentation
+More documentation is provided in the [project Wiki](https://github.com/genivi/franca_ara_tools/wiki) in GitHub.
+
 ## Development setup
 
 ### Eclipse


### PR DESCRIPTION
Just a quick fix to point to Wiki documentation.  
README might be organized differently if you want, feel free to rework it.