### PR TITLE
Feature/f2a aspects for franca broadcasts

### DIFF
--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/Franca2ARATransformation.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/Franca2ARATransformation.xtend
@@ -138,6 +138,16 @@ class Franca2ARATransformation extends Franca2ARABase {
 		if (parentInterface !== originalParentInterface) {
 			it.addAnnotation(ANNOTATION_LABEL_ORIGINAL_PARENT_INTERFACE, originalParentInterface.getARFullyQualifiedName)
 		}
+
+		// Selective broadcasts are not representable in an AUTOSAR model.
+		if (src.selective) {
+			getLogger.logError("The broadcast '" + originalParentInterface.name + "." + src.name + "' cannot be properly converted because selective broadcasts are not representable in an AUTOSAR model! (IDL1390)")
+		}
+
+		// Broadcast selectors are not representable in an AUTOSAR model.
+		if (!src.selector.isNullOrEmpty) {
+			getLogger.logError("The broadcast '" + originalParentInterface.name + "." + src.name + "' cannot be properly converted because broadcast selectors are not representable in an AUTOSAR model! (IDL1400)")
+		}
 	}
 
 	def addAnnotation(Identifiable objectToAnnotate, String labelText, String annotationText) {

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/Franca2ARATransformation.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/Franca2ARATransformation.xtend
@@ -53,7 +53,6 @@ class Franca2ARATransformation extends Franca2ARABase {
 		namesHierarchy.clear();
 		val FrancaNamesCollector francaNamesCollector = new FrancaNamesCollector
 		francaNamesCollector.fillNamesHierarchy(src, namesHierarchy)
-		namesHierarchy.dump
 
 		// Process the conversion.
 		createPrimitiveTypesPackage(null)
@@ -61,8 +60,6 @@ class Franca2ARATransformation extends Franca2ARABase {
 		// arPackages.add(createPrimitiveTypesPackage)
 		val elementPackage = src.createPackageHierarchyForElementPackage(it)
 		elementPackage.elements.addAll(src.interfaces.map[transform(elementPackage)])
-
-		namesHierarchy.dump
 	}
 	
 	def create fac.createServiceInterface transform(FInterface src, ARPackage targetPackage) {

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/franca2ara/ARAPackageCreator.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/franca2ara/ARAPackageCreator.xtend
@@ -35,9 +35,11 @@ class ARAPackageCreator extends Franca2ARABase {
 		return elementPackage
 	}
 	
-	def create fac.createARPackage createPackageWithName(String name, ARPackage parent) {
-		shortName = name
-		parent?.arPackages?.add(it)
+	def private createPackageWithName(String name, ARPackage parent) {
+		val ARPackage newPackage = fac.createARPackage
+		newPackage.shortName = name
+		parent?.arPackages?.add(newPackage)
+		newPackage
 	}
 
 	def ARPackage findArPackageForFrancaElement(FModelElement fModelElement) {

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/franca2ara/ARATypeCreator.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/franca2ara/ARATypeCreator.xtend
@@ -10,7 +10,6 @@ import org.eclipse.emf.ecore.util.EcoreUtil
 import org.franca.core.franca.FBasicTypeId
 import org.franca.core.franca.FCompoundType
 import org.franca.core.franca.FEnumerationType
-import org.franca.core.franca.FField
 import org.franca.core.franca.FIntegerInterval
 import org.franca.core.franca.FMapType
 import org.franca.core.franca.FType
@@ -148,12 +147,12 @@ class ARATypeCreator extends Franca2ARABase {
 		return null
 	}
 
-	def private create fac.createImplementationDataTypeElement createImplementationDataTypeElement(FField fField) {
-		it.shortName = fField.name
+	def create fac.createImplementationDataTypeElement createImplementationDataTypeElement(FTypedElement fTypedElement) {
+		it.shortName = fTypedElement.name
 		it.category = "TYPE_REFERENCE"
 		val dataDefProps = fac.createSwDataDefProps
 		val dataDefPropsConditional = fac.createSwDataDefPropsConditional
-		val typeRef = createDataTypeReference(fField.type, fField)
+		val typeRef = createDataTypeReference(fTypedElement.type, fTypedElement)
 		if (typeRef instanceof ImplementationDataType) {
 			dataDefPropsConditional.implementationDataType = typeRef
 		} else {

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/names/FrancaNamesCollector.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/names/FrancaNamesCollector.xtend
@@ -1,0 +1,112 @@
+package org.genivi.faracon.names
+
+import org.eclipse.emf.ecore.EObject
+import org.franca.core.franca.FArgument
+import org.franca.core.franca.FAttribute
+import org.franca.core.franca.FBroadcast
+import org.franca.core.franca.FEnumerator
+import org.franca.core.franca.FField
+import org.franca.core.franca.FInterface
+import org.franca.core.franca.FMethod
+import org.franca.core.franca.FModel
+import org.franca.core.franca.FModelElement
+import org.franca.core.franca.FType
+import org.franca.core.franca.FTypeCollection
+import org.franca.core.franca.FTypedElement
+
+class FrancaNamesCollector {
+
+	def fillNamesHierarchy(FModel fModel, NamesHierarchy namesHierarchy) {
+		fModel.processElement("", namesHierarchy)
+	}
+
+	protected def void processElement(EObject arbitraryElement, String namespace, NamesHierarchy namesHierarchy) {
+		val String localName = arbitraryElement.localName
+		var innerNamespace = namespace
+		if (!localName.nullOrEmpty) {
+			if (!innerNamespace.empty) {
+				innerNamespace += "."
+			}
+			innerNamespace += localName
+			namesHierarchy.insertFullyQualifiedName(innerNamespace, arbitraryElement.metaclassGroup, false)
+		}
+		val finalInnerNamespace = innerNamespace
+		arbitraryElement.eContents.forEach[processElement(finalInnerNamespace, namesHierarchy)]
+	}
+
+	protected dispatch def Class<?> getMetaclassGroup(EObject arbitraryElement) {
+		null
+	}
+	protected dispatch def Class<?> getMetaclassGroup(FModel fModel) {
+		FModel
+	}
+	protected dispatch def Class<?> getMetaclassGroup(FModelElement fModelElement) {
+		FModelElement
+	}
+	protected dispatch def Class<?> getMetaclassGroup(FBroadcast fBroadcast) {
+		FBroadcast
+	}
+	protected dispatch def Class<?> getMetaclassGroup(FEnumerator fEnumerator) {
+		FEnumerator
+	}
+	protected dispatch def Class<?> getMetaclassGroup(FTypedElement fTypedElement) {
+		FTypedElement
+	}
+	protected dispatch def Class<?> getMetaclassGroup(FArgument fArgument) {
+		FArgument
+	}
+	protected dispatch def Class<?> getMetaclassGroup(FAttribute fAttribute) {
+		FAttribute
+	}
+	protected dispatch def Class<?> getMetaclassGroup(FField fField) {
+		FField
+	}
+	protected dispatch def Class<?> getMetaclassGroup(FMethod fMethod) {
+		FMethod
+	}
+	protected dispatch def Class<?> getMetaclassGroup(FType fType) {
+		FType
+	}
+	protected dispatch def Class<?> getMetaclassGroup(FTypeCollection fTypeCollection) {
+		FTypeCollection
+	}
+	protected dispatch def Class<?> getMetaclassGroup(FInterface fInterface) {
+		FInterface
+	}
+
+	protected dispatch def getLocalName(EObject arbitraryElement) {
+		null
+	}
+	protected dispatch def getLocalName(FModel fModel) {
+		fModel.name
+	}
+	protected dispatch def getLocalName(FModelElement fModelElement) {
+		fModelElement.name
+	}
+
+
+/*
+	protected dispatch def void processElement(EObject arbitraryElement, String namespace, NamesHierarchy namesHierarchy) {
+		arbitraryElement.eContents.forEach[processElement(namespace, namesHierarchy)]
+	}
+
+	protected dispatch def void processElement(FModel fModel, String namespace, NamesHierarchy namesHierarchy) {
+		val innerNamespace = fModel.name
+		namesHierarchy.insertFullyQualifiedName(innerNamespace, FModel, false)
+		fModel.eContents.forEach[processElement(innerNamespace, namesHierarchy)]
+	}
+
+	protected dispatch def void processElement(FModelElement fModelElement, String namespace, NamesHierarchy namesHierarchy) {
+		val innerNamespace = namespace + "." + fModelElement.name
+		namesHierarchy.insertFullyQualifiedName(innerNamespace, fModelElement.class, false)
+		fModelElement.eContents.forEach[processElement(innerNamespace, namesHierarchy)]
+	}
+
+	protected dispatch def void processElement(FBroadcast fBroadcast, String namespace, NamesHierarchy namesHierarchy) {
+		val innerNamespace = namespace + "." + fBroadcast.name
+		namesHierarchy.insertFullyQualifiedName(innerNamespace, FBroadcast, false)
+		fBroadcast.eContents.forEach[processElement(innerNamespace, namesHierarchy)]
+	}
+*/
+
+}

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/names/NamesHierarchy.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/names/NamesHierarchy.xtend
@@ -1,0 +1,127 @@
+package org.genivi.faracon.names
+
+import java.util.List
+import org.genivi.faracon.logging.BaseWithLogger
+import org.genivi.faracon.logging.ILogger
+
+class NamesHierarchy extends BaseWithLogger {
+
+	static class NameNode {
+		String name
+		Class<?> metaclass
+		boolean artifical
+		List<NameNode> children
+
+		def NameNode insertName(String nameToInsert, Class<?> metaclassOfElement, boolean isNameOfArtificalElement) {
+			if (children === null) {
+				children = newArrayList
+			}
+			val newNameNode = new NameNode => [
+				name = nameToInsert
+				metaclass = metaclassOfElement
+				artifical = isNameOfArtificalElement
+			]
+			children += newNameNode
+			newNameNode
+		}
+		
+		def void dump(ILogger logger) {
+			logger.logInfo(name + " : " + metaclass?.name + (if (artifical) " [artifical]" else ""))
+			logger.increaseIndentationLevel
+			children?.forEach[dump(logger)]
+			logger.decreaseIndentationLevel
+		}
+	}
+
+	NameNode rootNode = new NameNode
+
+	def clear() {
+		rootNode = new NameNode
+		rootNode.class
+	}
+
+	def dump() {
+		rootNode.dump(logger)
+	}
+
+	def insertFullyQualifiedName(String fullyQualifiedName, Class<?> metaclass, boolean artifical) {
+		insertFullyQualifiedName(fullyQualifiedName.split("\\."), metaclass, artifical)
+	}
+
+	def insertFullyQualifiedName(String[] fullyQualifiedNameFragments, Class<?> metaclass, boolean artifical) {
+		var NameNode currentNode = rootNode
+		for (name : fullyQualifiedNameFragments) {
+			val NameNode matchingNameNode = currentNode.findMatchingNameNode(name)
+			if (matchingNameNode !== null) {
+				currentNode = matchingNameNode
+			} else {
+				currentNode = currentNode.insertName(name, null, artifical)
+			}
+		}
+		currentNode.metaclass = metaclass
+		currentNode.artifical = artifical
+	}
+
+	def String createAndInsertUniqueName(String fullyQualifiedNamespaceName, String desiredLocalName, Class<?> metaclass) {
+		createAndInsertUniqueName(fullyQualifiedNamespaceName.split("\\."), desiredLocalName, metaclass)
+	}
+
+	def String createAndInsertUniqueName(String[] fullyQualifiedNamespaceNameFragments, String desiredLocalName, Class<?> metaclass) {
+		var NameNode currentNode = rootNode
+		for (name : fullyQualifiedNamespaceNameFragments) {
+			val NameNode matchingNameNode = currentNode.findMatchingNameNode(name)
+			if (matchingNameNode !== null) {
+				currentNode = matchingNameNode
+			} else {
+				return null
+			}
+		}
+		var uniqueLocalName = desiredLocalName
+		while (currentNode.findMatchingNameNode(uniqueLocalName, metaclass) !== null) {
+			uniqueLocalName += "_"
+		}
+		currentNode.insertName(uniqueLocalName, metaclass, true).name
+	}
+
+	def containsFullyQualifiedName(String fullyQualifiedName) {
+		containsFullyQualifiedName(fullyQualifiedName.split("\\."))
+	}
+
+	def containsFullyQualifiedName(String[] fullyQualifiedNameFragments) {
+		var NameNode currentNode = rootNode
+		for (name : fullyQualifiedNameFragments) {
+			val NameNode matchingNameNode = currentNode.findMatchingNameNode(name)
+			if (matchingNameNode !== null) {
+				currentNode = matchingNameNode
+			} else {
+				return false
+			}
+		}
+		return true
+	}
+
+	protected def findMatchingNameNode(NameNode parentNode, String nameToFind) {
+		if (parentNode.children.nullOrEmpty) {
+			return null
+		}
+		for (nameNode : parentNode.children) {
+			if (nameNode.name == nameToFind) {
+				return nameNode
+			}
+		}
+		return null
+	}
+
+	protected def findMatchingNameNode(NameNode parentNode, String nameToFind, Class<?> metaclass) {
+		if (parentNode.children.nullOrEmpty) {
+			return null
+		}
+		for (nameNode : parentNode.children) {
+			if (nameNode.name == nameToFind && nameNode.metaclass == metaclass) {
+				return nameNode
+			}
+		}
+		return null
+	}
+
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/IDL1250_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/IDL1250_Tests.xtend
@@ -1,0 +1,29 @@
+package org.genivi.faracon.tests.aspects_for_franca_broadcasts.f2a
+
+import org.eclipse.xtext.testing.InjectWith
+import org.franca.core.dsl.tests.util.XtextRunner2_Franca
+import org.genivi.faracon.tests.util.FaraconTestsInjectorProvider
+import org.genivi.faracon.tests.util.Franca2ARATestBase
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Test cases for testing the conversion of the broadcasts set of an Franca interface definition.
+ */
+@RunWith(XtextRunner2_Franca)
+@InjectWith(FaraconTestsInjectorProvider)
+class IDL1250_Tests extends Franca2ARATestBase {
+
+	static final String LOCAL_FRANCA_MODELS = "src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/"
+
+	@Test
+	def void oneBroadcast() {	
+		transformAndCheck(LOCAL_FRANCA_MODELS, "oneBroadcast");
+	}
+
+	@Test
+	def void multipleMethods() {	
+		transformAndCheck(LOCAL_FRANCA_MODELS, "multipleBroadcasts");
+	}
+
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/IDL1370_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/IDL1370_Tests.xtend
@@ -1,5 +1,6 @@
 package org.genivi.faracon.tests.aspects_for_franca_broadcasts.f2a
 
+import autosar40.genericstructure.generaltemplateclasses.arpackage.ARPackage
 import autosar40.swcomponent.datatype.dataprototypes.VariableDataPrototype
 import com.google.inject.Inject
 import org.eclipse.xtext.testing.InjectWith
@@ -30,7 +31,8 @@ class IDL1370_Tests extends Franca2ARATestBase {
 		val FInterface fParentInterface = francaFac.createFInterface => [
 			broadcasts += fBroadcast
 		]
-		val VariableDataPrototype variableDataPrototype = franca2ARATransformation.transform(fBroadcast, fParentInterface)
+		val ARPackage arInterfacePackage = araFac.createARPackage
+		val VariableDataPrototype variableDataPrototype = franca2ARATransformation.transform(fBroadcast, fParentInterface, arInterfacePackage)
 		assertNotNull(variableDataPrototype)
 	}
 

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/IDL1370_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/IDL1370_Tests.xtend
@@ -1,0 +1,37 @@
+package org.genivi.faracon.tests.aspects_for_franca_broadcasts.f2a
+
+import autosar40.swcomponent.datatype.dataprototypes.VariableDataPrototype
+import com.google.inject.Inject
+import org.eclipse.xtext.testing.InjectWith
+import org.franca.core.dsl.tests.util.XtextRunner2_Franca
+import org.franca.core.franca.FBroadcast
+import org.franca.core.franca.FInterface
+import org.genivi.faracon.Franca2ARATransformation
+import org.genivi.faracon.tests.util.FaraconTestsInjectorProvider
+import org.genivi.faracon.tests.util.Franca2ARATestBase
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static org.junit.Assert.assertNotNull
+
+/**
+ * Test cases for testing that a Franca broadcast 'FBroadcast' is converted into an AUTOSAR object of the metatype 'VariableDataPrototype'.
+ */
+@RunWith(XtextRunner2_Franca)
+@InjectWith(FaraconTestsInjectorProvider)
+class IDL1370_Tests extends Franca2ARATestBase {
+
+	@Inject
+	var Franca2ARATransformation franca2ARATransformation
+
+	@Test
+	def void broadcastConversion() {
+		val FBroadcast fBroadcast = francaFac.createFBroadcast
+		val FInterface fParentInterface = francaFac.createFInterface => [
+			broadcasts += fBroadcast
+		]
+		val VariableDataPrototype variableDataPrototype = franca2ARATransformation.transform(fBroadcast, fParentInterface)
+		assertNotNull(variableDataPrototype)
+	}
+
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/IDL1380_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/IDL1380_Tests.xtend
@@ -31,4 +31,24 @@ class IDL1380_Tests extends Franca2ARATestBase {
 		transformAndCheck(LOCAL_FRANCA_MODELS, "broadcastWithMultipleArguments")
 	}
 
+	@Test
+	def void broadcastConflictWithUserStruct() {
+		transformAndCheck(LOCAL_FRANCA_MODELS, "broadcastConflictWithUserStruct")
+	}
+
+	@Test
+	def void broadcastDoubleConflictWithUserStructs() {
+		transformAndCheck(LOCAL_FRANCA_MODELS, "broadcastDoubleConflictWithUserStructs")
+	}
+
+	@Test
+	def void broadcastConflictWithUserEnum() {
+		transformAndCheck(LOCAL_FRANCA_MODELS, "broadcastConflictWithUserEnum")
+	}
+
+	@Test
+	def void broadcastNonConflictWithIdenticallyNamedMethod() {
+		transformAndCheck(LOCAL_FRANCA_MODELS, "broadcastNonConflictWithIdenticallyNamedMethod")
+	}
+
 }

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/IDL1380_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/IDL1380_Tests.xtend
@@ -1,0 +1,34 @@
+package org.genivi.faracon.tests.aspects_for_franca_broadcasts.f2a
+
+import org.eclipse.xtext.testing.InjectWith
+import org.franca.core.dsl.tests.util.XtextRunner2_Franca
+import org.genivi.faracon.tests.util.FaraconTestsInjectorProvider
+import org.genivi.faracon.tests.util.Franca2ARATestBase
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Test cases for testing the conversion of the set of arguments of a Franca broadcast.
+ */
+@RunWith(XtextRunner2_Franca)
+@InjectWith(FaraconTestsInjectorProvider)
+class IDL1380_Tests extends Franca2ARATestBase {
+
+	static final String LOCAL_FRANCA_MODELS = "src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/"
+
+	@Test
+	def void broadcastWithoutArguments() {
+		transformAndCheck(LOCAL_FRANCA_MODELS, "broadcastWithoutArguments")
+	}
+
+	@Test
+	def void broadcastWithOneArgument() {
+		transformAndCheck(LOCAL_FRANCA_MODELS, "broadcastWithOneArgument")
+	}
+
+	@Test
+	def void broadcastWithMultipleArguments() {
+		transformAndCheck(LOCAL_FRANCA_MODELS, "broadcastWithMultipleArguments")
+	}
+
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/IDL1390_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/IDL1390_Tests.xtend
@@ -1,0 +1,25 @@
+package org.genivi.faracon.tests.aspects_for_franca_broadcasts.f2a
+
+import org.eclipse.xtext.testing.InjectWith
+import org.franca.core.dsl.tests.util.XtextRunner2_Franca
+import org.genivi.faracon.tests.util.FaraconTestsInjectorProvider
+import org.genivi.faracon.tests.util.Franca2ARATestBase
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.genivi.faracon.logging.AbstractLogger
+
+/**
+ * Test cases for testing the conversion of Franca selective broadcasts.
+ */
+@RunWith(XtextRunner2_Franca)
+@InjectWith(FaraconTestsInjectorProvider)
+class IDL1390_Tests extends Franca2ARATestBase {
+
+	static final String LOCAL_FRANCA_MODELS = "src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/"
+
+	@Test(expected = AbstractLogger.StopOnErrorException)
+	def void selectiveBroadcast() {
+		transformAndCheck(LOCAL_FRANCA_MODELS, "selectiveBroadcast")
+	}
+
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/IDL1400_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/IDL1400_Tests.xtend
@@ -1,0 +1,25 @@
+package org.genivi.faracon.tests.aspects_for_franca_broadcasts.f2a
+
+import org.eclipse.xtext.testing.InjectWith
+import org.franca.core.dsl.tests.util.XtextRunner2_Franca
+import org.genivi.faracon.tests.util.FaraconTestsInjectorProvider
+import org.genivi.faracon.tests.util.Franca2ARATestBase
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.genivi.faracon.logging.AbstractLogger
+
+/**
+ * Test cases for testing the conversion of Franca broadcasts with a selector.
+ */
+@RunWith(XtextRunner2_Franca)
+@InjectWith(FaraconTestsInjectorProvider)
+class IDL1400_Tests extends Franca2ARATestBase {
+
+	static final String LOCAL_FRANCA_MODELS = "src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/"
+
+	@Test(expected = AbstractLogger.StopOnErrorException)
+	def void broadcastsWithSelectors() {
+		transformAndCheck(LOCAL_FRANCA_MODELS, "broadcastsWithSelectors")
+	}
+
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastConflictWithUserEnum.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastConflictWithUserEnum.fidl
@@ -2,12 +2,17 @@ package a1.b2.c3
 
 interface ExampleInterface {
 
-	broadcast broadcastWithMultipleArguments {
+	broadcast broadcastConflictWithUserEnum {
 		out {
 			Int8 argument_1
 			String argument_2
 			UInt32 argument_3
 		}
+	}
+
+	enumeration BroadcastConflictWithUserEnumData {
+		EnumConstant_1
+		EnumConstant_2
 	}
 
 }

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastConflictWithUserStruct.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastConflictWithUserStruct.fidl
@@ -2,12 +2,16 @@ package a1.b2.c3
 
 interface ExampleInterface {
 
-	broadcast broadcastWithMultipleArguments {
+	broadcast broadcastConflictWithUserStruct {
 		out {
 			Int8 argument_1
 			String argument_2
 			UInt32 argument_3
 		}
+	}
+
+	struct BroadcastConflictWithUserStructData {
+		UInt32 field
 	}
 
 }

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastDoubleConflictWithUserStructs.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastDoubleConflictWithUserStructs.fidl
@@ -1,0 +1,21 @@
+package a1.b2.c3
+
+interface ExampleInterface {
+
+	broadcast broadcastDoubleConflictWithUserStructs {
+		out {
+			Int8 argument_1
+			String argument_2
+			UInt32 argument_3
+		}
+	}
+
+	struct BroadcastDoubleConflictWithUserStructsData {
+		UInt32 field
+	}
+
+	struct BroadcastDoubleConflictWithUserStructsData_ {
+		UInt32 field
+	}
+
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastNonConflictWithIdenticallyNamedMethod.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastNonConflictWithIdenticallyNamedMethod.fidl
@@ -2,12 +2,15 @@ package a1.b2.c3
 
 interface ExampleInterface {
 
-	broadcast broadcastWithMultipleArguments {
+	broadcast broadcastNonConflictWithIdenticallyNamedMethod {
 		out {
 			Int8 argument_1
 			String argument_2
 			UInt32 argument_3
 		}
+	}
+
+	method BroadcastNonConflictWithIdenticallyNamedMethodData {
 	}
 
 }

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastWithMultipleArguments.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastWithMultipleArguments.fidl
@@ -1,0 +1,13 @@
+package a1.b2.c3
+
+interface ExampleInterface {
+
+	broadcast broadcastWithMultipleArguments {
+		out {
+			Int8 argument_1
+			String argument_2
+			UInt32 argument_3
+		}
+	}
+	
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastWithOneArgument.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastWithOneArgument.fidl
@@ -1,0 +1,11 @@
+package a1.b2.c3
+
+interface ExampleInterface {
+
+	broadcast broadcastWithOneArgument {
+		out {
+			UInt32 argument
+		}
+	}
+	
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastWithoutArguments.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastWithoutArguments.fidl
@@ -1,0 +1,8 @@
+package a1.b2.c3
+
+interface ExampleInterface {
+
+	broadcast broadcastWithoutArguments {
+	}
+	
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastsWithSelectors.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/broadcastsWithSelectors.fidl
@@ -1,0 +1,17 @@
+package a1.b2.c3
+
+interface ExampleInterface {
+
+	broadcast broadcastWithSelector:selectorName1 {
+		out {
+			UInt32 argument
+		}
+	}
+	
+	broadcast broadcastWithSelector:selectorName2 {
+		out {
+			String argument
+		}
+	}
+	
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/multipleBroadcasts.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/multipleBroadcasts.fidl
@@ -1,0 +1,29 @@
+package a1.b2.c3
+
+interface ExampleInterface {
+
+	broadcast broadcast_1 {
+		out {
+			UInt32 argument
+		}
+	}
+
+	broadcast broadcast_2 {
+		out {
+			UInt32 argument
+		}
+	}
+
+	broadcast broadcast_3 {
+		out {
+			UInt32 argument
+		}
+	}
+
+	broadcast broadcast_4 {
+		out {
+			UInt32 argument
+		}
+	}
+
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/oneBroadcast.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/oneBroadcast.fidl
@@ -1,0 +1,11 @@
+package a1.b2.c3
+
+interface ExampleInterface {
+
+	broadcast exampleBroadcast {
+		out {
+			UInt32 argument
+		}
+	}
+	
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/selectiveBroadcast.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_franca_broadcasts/f2a/selectiveBroadcast.fidl
@@ -1,0 +1,11 @@
+package a1.b2.c3
+
+interface ExampleInterface {
+
+	broadcast selectiveBroadcast selective {
+		out {
+			UInt32 argument
+		}
+	}
+	
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_franca_methods/f2a/IDL1460_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_franca_methods/f2a/IDL1460_Tests.xtend
@@ -103,7 +103,8 @@ class IDL1460_Tests extends Franca2ARATestBase {
 		val FInterface fParentInterface = francaFac.createFInterface => [
 			broadcasts += fBroadcast
 		]
-		val VariableDataPrototype variableDataPrototype = franca2ARATransformation.transform(fBroadcast, fParentInterface)
+		val ARPackage arInterfacePackage = araFac.createARPackage
+		val VariableDataPrototype variableDataPrototype = franca2ARATransformation.transform(fBroadcast, fParentInterface, arInterfacePackage)
 		checkAbstractBaseClasses(fBroadcast, variableDataPrototype)
 	}
 

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_franca_methods/f2a/IDL1470_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_franca_methods/f2a/IDL1470_Tests.xtend
@@ -105,7 +105,8 @@ class IDL1470_Tests extends Franca2ARATestBase {
 		val FInterface fParentInterface = francaFac.createFInterface => [
 			broadcasts += fBroadcast
 		]
-		val VariableDataPrototype variableDataPrototype = franca2ARATransformation.transform(fBroadcast, fParentInterface)
+		val ARPackage arInterfacePackage = araFac.createARPackage
+		val VariableDataPrototype variableDataPrototype = franca2ARATransformation.transform(fBroadcast, fParentInterface, arInterfacePackage)
 		checkNamesEquality(fBroadcast, variableDataPrototype)
 	}
 

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_franca_methods/f2a/arrayMethodInputArgument.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_franca_methods/f2a/arrayMethodInputArgument.fidl
@@ -4,7 +4,7 @@ interface ExampleInterface {
 
 	method exampleMethod {
 		in {
-			UInt32 input_argument[23]
+			UInt32[] input_argument
 		}
 	}
 	


### PR DESCRIPTION
The checking of possible name conflicts does not completely cover the situation of a package beside an interface that has the same name as the interface.
But it has to be clarified if this situation principally makes sense.