### PR TITLE
Feature/aspects on imports

### DIFF
--- a/plugins/org.genivi.faracon.cli/META-INF/MANIFEST.MF
+++ b/plugins/org.genivi.faracon.cli/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.franca.core.dsl;bundle-version="[0.9.0,0.13.2)";visibility:=reexport,
  org.franca.deploymodel.dsl;bundle-version="[0.9.0,0.13.2)";visibility:=reexport,
  org.genivi.faracon.console,
- org.genivi.faracon;bundle-version="0.7.0"
+ org.genivi.faracon;bundle-version="0.7.0",
+ org.eclipse.xtend.lib;bundle-version="2.14.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.genivi.faracon.cli
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/plugins/org.genivi.faracon.cli/plugin.xml
+++ b/plugins/org.genivi.faracon.cli/plugin.xml
@@ -92,7 +92,15 @@
                   required="false"
                   shortName="c">
             </option>
-
+			<option
+                  argCount="0"
+                  description="Checks the provided ARXML files."
+                  hasOptionalArg="false"
+                  id="org.genivi.faracon.cli.option.checkarxmlfiles"
+                  longName="check-arxml-files-only"
+                  required="false"
+                  shortName="ca">
+            </option>
          </options>
       </command>
    </extension>

--- a/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/Ara2FrancaConverter.xtend
+++ b/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/Ara2FrancaConverter.xtend
@@ -1,0 +1,133 @@
+package org.genivi.faracon.cli
+
+import java.util.Collection
+import javax.inject.Inject
+import org.eclipse.emf.common.util.URI
+import org.eclipse.emf.ecore.util.EcoreUtil
+import org.eclipse.xtext.resource.XtextResourceSet
+import org.franca.core.dsl.FrancaPersistenceManager
+import org.franca.core.framework.FrancaModelContainer
+import org.franca.core.utils.FileHelper
+import org.genivi.faracon.ARAConnector
+import org.genivi.faracon.ARAModelContainer
+import org.genivi.faracon.ARAResourceSet
+import org.genivi.faracon.FrancaMultiModelContainer
+import org.genivi.faracon.logging.BaseWithLogger
+import org.genivi.faracon.preferences.Preferences
+import org.genivi.faracon.preferences.PreferencesConstants
+
+import static org.genivi.faracon.cli.ConverterHelper.*
+
+class Ara2FrancaConverter extends BaseWithLogger {
+	
+	@Inject
+	var ARAConnector araConnector
+	@Inject
+	var FrancaPersistenceManager francaLoader
+	
+	val Preferences preferences
+
+	new(){
+		preferences = Preferences.getInstance();
+	}
+
+	def void convertARAFiles(Collection<String> araFilePaths) {
+		if (araFilePaths.nullOrEmpty) {
+			return 
+		}
+
+		getLogger().logInfo("Converting Adaptive AUTOSAR IDL models to Franca IDL models...");
+		getLogger().increaseIndentationLevel();
+
+		val modelContainers = loadAllAraFiles(araFilePaths)
+		val ara2FrancaMultiModelContainers = modelContainers.transformToFranca()
+		ara2FrancaMultiModelContainers.putAllFrancaModelsInOneResource
+		ara2FrancaMultiModelContainers.saveAllFrancaModels
+
+		getLogger().decreaseIndentationLevel();
+	}
+
+	/**
+	 * The methods loads all ARA files into a single resource Set and resolves all objects
+	 */
+	def Collection<ARAModelContainer> loadAllAraFiles(Collection<String> araFilePaths) {
+		val araResourceSet = new ARAResourceSet();
+		val modelContainer = araFilePaths.map [ araFilePath |
+			val normalizedARAFilePath = normalize(araFilePath);
+			getLogger().logInfo("Loading arxml file " + normalizedARAFilePath);
+			getLogger().increaseIndentationLevel();
+			var ARAModelContainer araModelContainer;
+			try {
+				araModelContainer = araConnector.loadModel(araResourceSet, normalizedARAFilePath) as ARAModelContainer;
+			} catch (Exception e) {
+				getLogger().logError("File " + normalizedARAFilePath + " could not be loaded!");
+				getLogger().decreaseIndentationLevel();
+				return null
+			}
+
+			val araModelUri = araModelContainer.model().eResource().getURI();
+			if (!araModelUri.fileExtension().toLowerCase().equals("arxml")) {
+				getLogger().logWarning("The Adaptive AUTOSAR file " + normalizedARAFilePath +
+					" does not have the file extension \"arxml\".");
+				return null
+			}
+			logger.decreaseIndentationLevel();
+			return araModelContainer
+
+		].filterNull.toList
+		EcoreUtil.resolveAll(araResourceSet);
+		return modelContainer
+	}
+
+	def Collection<Pair<ARAModelContainer, FrancaMultiModelContainer>> transformToFranca(
+		Collection<ARAModelContainer> containers) {
+		containers.map [ araModelContainer |
+			getLogger().logInfo("Converting arxml file " + araModelContainer?.model?.eResource?.URI);
+			val francaMultiModelContainer = araConnector.toFranca(araModelContainer) as FrancaMultiModelContainer;
+			return araModelContainer -> francaMultiModelContainer
+		].toList
+	}
+
+	def putAllFrancaModelsInOneResource(
+		Collection<Pair<ARAModelContainer, FrancaMultiModelContainer>> ara2FrancaMultiModelContainers) {
+		val resourceSet = new XtextResourceSet();
+		ara2FrancaMultiModelContainers.forEach [
+			it.value.francaModelContainers.forEach [ francaModelContainer |
+				// put all Franca models in to one resource set
+				val araModelUri = it.key.model().eResource().getURI();
+				val francaFilePath = getFrancaFilePath(araModelUri, francaModelContainer);
+				val resource = resourceSet.createResource(FileHelper.createURI(francaFilePath));
+				resource.getContents().add(francaModelContainer.model());
+			]
+		]
+	}
+
+	def saveAllFrancaModels(
+		Collection<Pair<ARAModelContainer, FrancaMultiModelContainer>> ara2FrancaMultiModelContainers) {
+		ara2FrancaMultiModelContainers.forEach [
+			it.value.francaModelContainers.forEach [ francaModelContainer |
+				// Store the output FrancaIDL model.
+				val araModelUri = it.key.model().eResource().getURI();
+				val francaFilePath = getFrancaFilePath(araModelUri, francaModelContainer);
+				getLogger().logInfo("Storing FrancaIDL file " + francaFilePath);
+				francaLoader.saveModel(francaModelContainer.model(), francaFilePath);
+			]
+		]
+	}
+
+	def private String getFrancaFilePath(URI araModelUri, FrancaModelContainer francaModelContainer) {
+		val transformedModelUri = OutputFileHelper.calculateFrancaOutputUri(araModelUri, francaModelContainer);
+		var String outputDirectoryPath = null;
+		try {
+			outputDirectoryPath = preferences.getPreference(PreferencesConstants.P_OUTPUT_DIRECTORY_PATH, "");
+		} catch (Preferences.UnknownPreferenceException e) {
+			getLogger().logError(e.getMessage());
+		}
+		if (!outputDirectoryPath.isEmpty()) {
+			outputDirectoryPath += "/";
+		}
+		val relativeFrancaFilePath = outputDirectoryPath + transformedModelUri.lastSegment()
+		val francaFilePath = normalize(relativeFrancaFilePath);
+		return francaFilePath;
+	}
+}

--- a/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/Ara2FrancaConverter.xtend
+++ b/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/Ara2FrancaConverter.xtend
@@ -44,7 +44,7 @@ class Ara2FrancaConverter extends BaseWithLogger {
 		val Collection<ARAModelContainer> modelContainers = loadAllAraFiles(araFilePaths)
 		resolveProxiesAndCheckRemaining
 		val ara2FrancaMultiModelContainers = modelContainers.transformToFranca()
-		ara2FrancaMultiModelContainers.putAllFrancaModelsInOneResource
+		ara2FrancaMultiModelContainers.putAllFrancaModelsInOneResourceSet
 		ara2FrancaMultiModelContainers.saveAllFrancaModels
 
 		getLogger().decreaseIndentationLevel();
@@ -114,7 +114,7 @@ class Ara2FrancaConverter extends BaseWithLogger {
 		].toList
 	}
 
-	def putAllFrancaModelsInOneResource(
+	def putAllFrancaModelsInOneResourceSet(
 		Collection<Pair<ARAModelContainer, FrancaMultiModelContainer>> ara2FrancaMultiModelContainers) {
 		val resourceSet = new XtextResourceSet();
 		ara2FrancaMultiModelContainers.forEach [

--- a/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/ConverterCliCommand.java
+++ b/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/ConverterCliCommand.java
@@ -1,27 +1,11 @@
 package org.genivi.faracon.cli;
 
-import java.io.File;
 import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.xtext.validation.AbstractValidationMessageAcceptor;
-import org.eclipse.xtext.validation.ValidationMessageAcceptor;
-import org.franca.core.dsl.FrancaPersistenceManager;
-import org.franca.core.framework.FrancaModelContainer;
-import org.franca.core.franca.FModel;
-import org.genivi.faracon.ARAConnector;
-import org.genivi.faracon.ARAModelContainer;
-import org.genivi.faracon.FrancaMultiModelContainer;
 import org.genivi.faracon.console.CommandlineTool;
-//import org.genivi.faracon.generator.GeneratorFileSystemAccess;
-//import org.genivi.faracon.verification.CommandlineValidator;
-//import org.genivi.faracon.verification.ValidatorCore;
-//import org.genivi.faracon.generator.FrancaDBusGenerator;
 import org.genivi.faracon.preferences.Preferences;
 import org.genivi.faracon.preferences.PreferencesConstants;
 
@@ -30,43 +14,11 @@ import com.google.inject.Inject;
 public class ConverterCliCommand extends CommandlineTool {
 
 	@Inject
-	protected ARAConnector araConnector;
-
+	private Franca2AraConverter franca2AraConverter;
 	@Inject
-	protected FrancaPersistenceManager francaLoader;
+	private Ara2FrancaConverter ara2FrancaConverter;
 
-//	@Inject
-//	protected GeneratorFileSystemAccess fsa;
-
-	protected Preferences preferences;
-
-//	@Inject
-//	protected IGenerator francaGenerator;
-//	protected FrancaDBusGenerator francaGenerator;
-
-	protected String SCOPE = "DBus validation: ";
-
-	private ValidationMessageAcceptor cliMessageAcceptor = new AbstractValidationMessageAcceptor() {
-
-		@Override
-		public void acceptInfo(String message, EObject object, EStructuralFeature feature, int index, String code,
-				String... issueData) {
-			getLogger().logInfo(SCOPE + message);
-		}
-
-		@Override
-		public void acceptWarning(String message, EObject object, EStructuralFeature feature, int index, String code,
-				String... issueData) {
-			getLogger().logWarning(SCOPE + message);
-		}
-
-		@Override
-		public void acceptError(String message, EObject object, EStructuralFeature feature, int index, String code,
-				String... issueData) {
-			hasValidationError = true;
-			getLogger().logError(SCOPE + message);
-		}
-	};
+	private Preferences preferences;
 
 	/**
 	 * The constructor registers the needed bindings to use the generator
@@ -109,8 +61,7 @@ public class ConverterCliCommand extends CommandlineTool {
 
 		String[] francaFilePaths = parsedArguments.getOptionValues('f');
 		String[] araFilePaths = parsedArguments.getOptionValues('a');
-//		// We expect at least one fidl/fdepl file as command line argument
-//		if (files.size() > 0 && files.get(0) != null) {
+
 		boolean haveFrancaInput = francaFilePaths != null && francaFilePaths.length > 0;
 		boolean haveARAInput = araFilePaths != null && araFilePaths.length > 0;
 		if (!haveFrancaInput && !haveARAInput) {
@@ -119,11 +70,6 @@ public class ConverterCliCommand extends CommandlineTool {
 		if (haveFrancaInput && haveARAInput) {
 			getLogger().logWarning("A mix of FrancaIDL and Adaptive AUTOSAR input model files is given.");
 		}
-//		// a search path may be specified, collect all fidl/fdepl files
-//		if (parsedArguments.hasOption("sp")) {
-//			files.addAll(cliTool.searchFidlandFdeplFiles(parsedArguments
-//					.getOptionValue("sp")));
-//		}
 
 		// destination: -d --dest overwrite default output directory path
 		if (parsedArguments.hasOption("d")) {
@@ -136,261 +82,28 @@ public class ConverterCliCommand extends CommandlineTool {
 			setLicenseText(parsedArguments.getOptionValue("L"));
 		}
 
-//			// Switch off validation
-//			if (parsedArguments.hasOption("nv")) {
-//				cliTool.disableValidation();
-//			}
-
 		getLogger().decreaseIndentationLevel();
 
 		Collection<String> fidlFiles = FilePathsHelper.findFiles(francaFilePaths, "fidl");
 		Collection<String> araFiles = FilePathsHelper.findFiles(francaFilePaths, "arxml");
-		
+
 		// Invoke the converters.
-		convertFrancaFiles(fidlFiles);
-		convertARAFiles(araFiles);
+		this.convertARAFiles(araFiles);
+		this.convertFrancaFiles(fidlFiles);
 
 		return 0;
 	}
+
+	public void convertARAFiles(Collection<String> araFiles) {
+		ara2FrancaConverter.convertARAFiles(araFiles);
+	}
 	
-	public void convertFrancaFiles(Collection<String> francaFilePaths) {
-		if (francaFilePaths == null || francaFilePaths.isEmpty()) {
-			return;
-		}
-
-		getLogger().logInfo("Converting Franca IDL models to Adaptive AUTOSAR IDL models...");
-		getLogger().increaseIndentationLevel();
-
-		for (String francaFilePath : francaFilePaths) {
-			// Load an input FrancaIDL model.
-			String normalizedFrancaFilePath = normalize(francaFilePath);
-			getLogger().logInfo("Loading FrancaIDL file " + normalizedFrancaFilePath);
-			getLogger().increaseIndentationLevel();
-			FModel francaModel;
-			try {
-				francaModel = francaLoader.loadModel(normalizedFrancaFilePath);
-			} catch (Exception e) {
-				getLogger().logError("File " + normalizedFrancaFilePath + " could not be loaded!");
-				getLogger().decreaseIndentationLevel();
-				continue;
-			}
-			if (francaModel == null) {
-				getLogger().logError("File " + normalizedFrancaFilePath + " could not be loaded!");
-				getLogger().decreaseIndentationLevel();
-				continue;
-			}
-			URI francaModelUri = francaModel.eResource().getURI();
-			if (!francaModelUri.fileExtension().toLowerCase().equals("fidl")) {
-				getLogger().logWarning("The FrancaIDL file " + normalizedFrancaFilePath
-						+ " does not have the file extension \"fidl\".");
-			}
-			getLogger().decreaseIndentationLevel();
-
-			// Transform the FrancaIDL model to an arxml model.
-			getLogger().logInfo("Converting FrancaIDL file " + normalizedFrancaFilePath);
-			ARAModelContainer araModelContainer = (ARAModelContainer) araConnector.fromFranca(francaModel);
-
-			// Store the output arxml model.
-			URI transformedModelUri = francaModelUri.trimFileExtension().appendFileExtension("arxml");
-			String outputDirectoryPath = null;
-			try {
-				outputDirectoryPath = preferences.getPreference(PreferencesConstants.P_OUTPUT_DIRECTORY_PATH, "");
-			} catch (Preferences.UnknownPreferenceException e) {
-				getLogger().logError(e.getMessage());
-			}
-			if (!outputDirectoryPath.isEmpty()) {
-				outputDirectoryPath += "/";
-			}
-			String araFilePath = normalize(outputDirectoryPath + transformedModelUri.lastSegment());
-			getLogger().logInfo("Storing arxml file " + araFilePath);
-			araConnector.saveModel(araModelContainer, araFilePath);
-		}
-
-		getLogger().decreaseIndentationLevel();
+	public void convertFrancaFiles(Collection<String> fidlFiles) {
+		franca2AraConverter.convertFrancaFiles(fidlFiles);
 	}
-
-	public void convertARAFiles(Collection<String> araFilePaths) {
-		if (araFilePaths == null || araFilePaths.isEmpty()) {
-			return;
-		}
-
-		getLogger().logInfo("Converting Adaptive AUTOSAR IDL models to Franca IDL models...");
-		getLogger().increaseIndentationLevel();
-
-		for (String araFilePath : araFilePaths) {
-			// Load an input arxml model.
-			String normalizedARAFilePath = normalize(araFilePath);
-			getLogger().logInfo("Loading arxml file " + normalizedARAFilePath);
-			getLogger().increaseIndentationLevel();
-			ARAModelContainer araModelContainer;
-			try {
-				araModelContainer = (ARAModelContainer) araConnector.loadModel(normalizedARAFilePath);
-			} catch (Exception e) {
-				getLogger().logError("File " + normalizedARAFilePath + " could not be loaded!");
-				getLogger().decreaseIndentationLevel();
-				continue;
-			}
-			URI araModelUri = araModelContainer.model().eResource().getURI();
-			if (!araModelUri.fileExtension().toLowerCase().equals("arxml")) {
-				getLogger().logWarning("The Adaptive AUTOSAR file " + normalizedARAFilePath
-						+ " does not have the file extension \"arxml\".");
-			}
-			getLogger().decreaseIndentationLevel();
-
-			// Transform the arxml model to a FrancaIDL model.
-			getLogger().logInfo("Converting arxml file " + normalizedARAFilePath);
-			FrancaMultiModelContainer fmodel = (FrancaMultiModelContainer) araConnector.toFranca(araModelContainer);
-			
-			String outputDirectoryPath = null;
-			try {
-				outputDirectoryPath = preferences.getPreference(PreferencesConstants.P_OUTPUT_DIRECTORY_PATH, "");
-			} catch (Preferences.UnknownPreferenceException e) {
-				getLogger().logError(e.getMessage());
-			}
-			if (!outputDirectoryPath.isEmpty()) {
-				outputDirectoryPath += "/";
-			}
-			
-			for (FrancaModelContainer francaModelContainer : fmodel.getFrancaModelContainers()) {
-				// Store the output FrancaIDL model.
-				URI transformedModelUri = OutputFileHelper.calculateFrancaOutputUri(araModelUri, fmodel, francaModelContainer);
-
-				String francaFilePath = normalize(outputDirectoryPath + transformedModelUri.lastSegment());
-				getLogger().logInfo("Storing FrancaIDL file " + francaFilePath);
-				francaLoader.saveModel(fmodel.model(), francaFilePath);
-			}
-		}
-
-		getLogger().decreaseIndentationLevel();
-	}
-
-	protected String normalize(String _path) {
-		File itsFile = new File(_path);
-		return itsFile.getAbsolutePath();
-	}
-
-//	/**
-//	 * Call the franca generator for the specified list of files.
-//	 *
-//	 * @param fileList
-//	 *            the list of files to generate code from
-//	 */
-//	protected int doGenerate(List<String> _fileList) {
-//		fsa.setOutputConfigurations(Preferences.getInstance()
-//				.getOutputpathConfiguration());
-//
-//		XtextResourceSet rsset = injector.getProvider(XtextResourceSet.class)
-//				.get();
-//
-//		int error_state = NO_ERROR_STATE;
-//		getLogger().logInfo("Using Franca Version " + getFrancaVersion());
-//
-//		// Create absolute paths
-//		List<String> fileList = new ArrayList<String>();
-//		for (String path : _fileList) {
-//			String absolutePath = normalize(path);
-//			fileList.add(absolutePath);
-//		}
-//
-//		for (String file : fileList) {
-//			URI uri = URI.createFileURI(file);
-//			Resource resource = null;
-//			try {
-//				resource = rsset.createResource(uri);
-//			} catch (IllegalStateException ise) {
-//				getLogger().logError("Failed to create a resource from "
-//						+ file + "\n" + ise.getMessage());
-//				error_state = ERROR_STATE;
-//				continue;
-//			}
-//			hasValidationError = false;
-//			if (isValidation) {
-//				validateDBus(resource);
-//			}
-//			if (!hasValidationError) {
-//				getLogger().logInfo("Generating code for " + file);
-//				try {
-//					if (Preferences.getInstance().getPreference(
-//							PreferencesConstants.P_OUTPUT_SUBDIRS_DBUS, "false").equals("true")) {
-//						String subdir = (new File(file)).getName();
-//						subdir = subdir.replace(".fidl", "");
-//						subdir = subdir.replace(".fdepl", "");
-//						fsa.setOutputConfigurations(Preferences.getInstance()
-//							.getOutputpathConfiguration(subdir));
-//					}
-////					francaGenerator.doGenerate(resource, fsa);
-//				} catch (Exception e) {
-//					getLogger()
-//							.logError("Failed to generate dbus code: "
-//									+ e.getMessage());
-//					error_state = ERROR_STATE;
-//				}
-//			} else {
-//				error_state = ERROR_STATE;
-//			}
-//			if (resource != null) {
-//				// Clear each resource from the resource set in order to let
-//				// other fidl files import it.
-//				// Otherwise an IllegalStateException will be thrown for a
-//				// resource that was already created.
-//				resource.unload();
-//				rsset.getResources().clear();
-//			}
-//		}
-//		if (dumpGeneratedFiles) {
-//			fsa.dumpGeneratedFiles();
-//		}
-//		fsa.clearFileList();
-//		dumpGeneratedFiles = false;
-//		return error_state;
-//	}
-
-//	/**
-//	 * Validate the fidl/fdepl file resource
-//	 *
-//	 * @param resource
-//	 */
-//	public void validateDBus(Resource resource) {
-//		EObject model = null;
-//		CommandlineValidator cliValidator = new CommandlineValidator(
-//				cliMessageAcceptor);
-//
-//		//getLogger().logInfo("validating " + resource.getURI().lastSegment());
-//
-//		model = cliValidator.loadResource(resource);
-//
-//		if (model != null) {
-//			if (model instanceof FDModel) {
-//				// Many error logs would be displayed if a SomeIP deployment file had DBus
-//				// deployment information (or vice versa).
-//				// Therefore don't validate fdepl files for DBus at the moment
-//				return;
-//				// cliValidator.validateImports((FDModel) model, resource.getURI());
-//			}
-//			// check existence of imported fidl/fdepl files
-//			if (model instanceof FModel) {
-//				cliValidator.validateImports((FModel) model, resource.getURI());
-//
-//				// validate against GENIVI rules
-//				ValidatorCore validator = new ValidatorCore();
-//				try {
-//					validator.validateModel((FModel) model, cliMessageAcceptor);
-//				} catch (Exception e) {
-//					getLogger().logError(e.getMessage());
-//					hasValidationError = true;
-//					return;
-//				}
-//			}
-//			// XText validation
-//			cliValidator.validateResourceWithImports(resource);
-//		} else {
-//			// model is null, no resource factory was registered !
-//			hasValidationError = true;
-//		}
-//	}
 
 	public void setOutputDirectoryPath(String outputDirectoryPath) {
-		String normalizedOutputDirectoryPath = normalize(outputDirectoryPath);
+		String normalizedOutputDirectoryPath = ConverterHelper.normalize(outputDirectoryPath);
 		getLogger().logInfo("Output directory path: " + normalizedOutputDirectoryPath);
 		preferences.setPreference(PreferencesConstants.P_OUTPUT_DIRECTORY_PATH, normalizedOutputDirectoryPath);
 	}
@@ -420,11 +133,6 @@ public class ConverterCliCommand extends CommandlineTool {
 		getLogger().enableContinueOnErrors(enabled);
 	}
 
-//	public void disableValidation() {
-//		getLogger().logInfo("Validation is off");
-//		isValidation = false;
-//	}
-
 	/**
 	 * Set the text from a file which will be inserted as a comment in each
 	 * generated file (for example your license)
@@ -444,10 +152,6 @@ public class ConverterCliCommand extends CommandlineTool {
 	@Override
 	public String getFrancaVersion() {
 		return Platform.getBundle("org.franca.core").getVersion().toString();
-	}
-
-	public void listGeneratedFiles() {
-		dumpGeneratedFiles = true;
 	}
 
 }

--- a/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/ConverterCliCommand.java
+++ b/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/ConverterCliCommand.java
@@ -85,7 +85,7 @@ public class ConverterCliCommand extends CommandlineTool {
 		getLogger().decreaseIndentationLevel();
 
 		Collection<String> fidlFiles = FilePathsHelper.findFiles(francaFilePaths, "fidl");
-		Collection<String> araFiles = FilePathsHelper.findFiles(francaFilePaths, "arxml");
+		Collection<String> araFiles = FilePathsHelper.findFiles(araFilePaths, "arxml");
 
 		// Invoke the converters.
 		this.convertARAFiles(araFiles);

--- a/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/ConverterCliCommand.java
+++ b/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/ConverterCliCommand.java
@@ -53,6 +53,13 @@ public class ConverterCliCommand extends CommandlineTool {
 		if (parsedArguments.hasOption("c")) {
 			setContinueOnErrors(true);
 		}
+		
+		// -ca --check ARXML files
+		boolean checkArXmlFilesOnly = false;
+		if(parsedArguments.hasOption("ca")) {
+			getLogger().logInfo("Option \"ca\" set. Only the ARXML files will be checked. No tranformation will be executed.");
+			checkArXmlFilesOnly = true;
+		}
 
 		List<String> commandLineArguments = parsedArguments.getArgList();
 		for (String commandLineArgument : commandLineArguments) {
@@ -87,6 +94,14 @@ public class ConverterCliCommand extends CommandlineTool {
 		Collection<String> fidlFiles = FilePathsHelper.findFiles(francaFilePaths, "fidl");
 		Collection<String> araFiles = FilePathsHelper.findFiles(araFilePaths, "arxml");
 
+		if(checkArXmlFilesOnly) {
+			ara2FrancaConverter.loadAllAraFiles(araFiles);
+			setContinueOnErrors(true);
+			int foundRemainingProxies = ara2FrancaConverter.resolveProxiesAndCheckRemaining();
+			getLogger().logInfo("Found " + foundRemainingProxies + " unresolved objects in input files.");
+			return foundRemainingProxies;
+		}
+		
 		// Invoke the converters.
 		this.convertARAFiles(araFiles);
 		this.convertFrancaFiles(fidlFiles);

--- a/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/ConverterHelper.xtend
+++ b/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/ConverterHelper.xtend
@@ -1,0 +1,14 @@
+package org.genivi.faracon.cli
+
+import java.io.File
+
+class ConverterHelper {
+	new(){
+		
+	}
+	
+	def static String normalize(String _path) {
+		val itsFile = new File(_path);
+		return itsFile.getAbsolutePath();
+	}
+}

--- a/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/FilePathsHelper.xtend
+++ b/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/FilePathsHelper.xtend
@@ -15,6 +15,9 @@ class FilePathsHelper {
 
 	def static Collection<String> findFiles(String[] filePaths, String fileExtension) {
 		val files = newHashSet()
+		if(null === filePaths){
+			return files
+		}
 		filePaths.forEach [
 			val fileVisitor = new SimpleFileVisitor<Path>() {
 				override visitFile(Path path, BasicFileAttributes attrs) {

--- a/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/Franca2AraConverter.xtend
+++ b/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/Franca2AraConverter.xtend
@@ -1,0 +1,84 @@
+package org.genivi.faracon.cli
+
+import java.util.Collection
+import javax.inject.Inject
+import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+import org.franca.core.dsl.FrancaPersistenceManager
+import org.franca.core.franca.FModel
+import org.genivi.faracon.ARAConnector
+import org.genivi.faracon.ARAModelContainer
+import org.genivi.faracon.logging.BaseWithLogger
+import org.genivi.faracon.preferences.Preferences
+import org.genivi.faracon.preferences.PreferencesConstants
+
+import static org.genivi.faracon.cli.ConverterHelper.*
+
+class Franca2AraConverter extends BaseWithLogger{
+	@Inject
+	var ARAConnector araConnector
+	@Inject
+	var FrancaPersistenceManager francaLoader
+	
+	val Preferences preferences
+
+	new(){
+		preferences = Preferences.getInstance();
+	}
+
+	def void convertFrancaFiles(Collection<String> francaFilePaths) {
+		if (francaFilePaths.nullOrEmpty) {
+			return;
+		}
+
+		getLogger().logInfo("Converting Franca IDL models to Adaptive AUTOSAR IDL models...");
+		getLogger().increaseIndentationLevel();
+		
+		for (String francaFilePath : francaFilePaths) {
+			// Load an input FrancaIDL model.
+			val normalizedFrancaFilePath = normalize(francaFilePath);
+			getLogger().logInfo("Loading FrancaIDL file " + normalizedFrancaFilePath);
+			getLogger().increaseIndentationLevel();
+			var FModel francaModel;
+			try {
+				francaModel = francaLoader.loadModel(normalizedFrancaFilePath);
+			} catch (Exception e) {
+				getLogger().logError("File " + normalizedFrancaFilePath + " could not be loaded!");
+				getLogger().decreaseIndentationLevel();
+				return
+			}
+			if (francaModel === null) {
+				getLogger().logError("File " + normalizedFrancaFilePath + " could not be loaded!");
+				getLogger().decreaseIndentationLevel();
+				return
+			}
+			val francaModelUri = francaModel.eResource().getURI();
+			if (!francaModelUri.fileExtension().toLowerCase().equals("fidl")) {
+				getLogger().logWarning("The FrancaIDL file " + normalizedFrancaFilePath
+						+ " does not have the file extension \"fidl\".");
+			}
+			getLogger().decreaseIndentationLevel();
+
+			// Transform the FrancaIDL model to an arxml model.
+			getLogger().logInfo("Converting FrancaIDL file " + normalizedFrancaFilePath)
+			val araModelContainer = araConnector.fromFranca(francaModel) as ARAModelContainer
+
+			// Store the output arxml model.
+			val transformedModelUri = francaModelUri.trimFileExtension().appendFileExtension("arxml");
+			var String outputDirectoryPath = null;
+			try {
+				outputDirectoryPath = preferences.getPreference(PreferencesConstants.P_OUTPUT_DIRECTORY_PATH, "");
+			} catch (Preferences.UnknownPreferenceException e) {
+				getLogger().logError(e.getMessage());
+			}
+			if (!outputDirectoryPath.isEmpty()) {
+				outputDirectoryPath += "/";
+			}
+			val String araFilePath = normalize(outputDirectoryPath + transformedModelUri.lastSegment());
+			getLogger().logInfo("Storing arxml file " + araFilePath);
+			araConnector.saveModel(araModelContainer, araFilePath);
+		}
+
+		getLogger().decreaseIndentationLevel();
+	}
+	 
+}

--- a/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/OutputFileHelper.xtend
+++ b/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/OutputFileHelper.xtend
@@ -1,26 +1,20 @@
 package org.genivi.faracon.cli
 
-import org.genivi.faracon.FrancaMultiModelContainer
 import org.eclipse.emf.common.util.URI
 import org.franca.core.framework.FrancaModelContainer
 
+import static org.genivi.faracon.ara2franca.Ara2FrancaUtil.*
+
 class OutputFileHelper {
-	private new(){}
-	 
-	def static calculateFrancaOutputUri(URI araModelUri, FrancaMultiModelContainer multiContainer,
-			FrancaModelContainer francaModelContainer){
+	private new() {
+	}
+
+	def static calculateFrancaOutputUri(URI araModelUri, FrancaModelContainer francaModelContainer) {
+		val francaFileName = calculateFrancaFileName(francaModelContainer.model(), araModelUri)
 		var transformedModelUri = araModelUri.trimFileExtension();
-		if (multiContainer.francaModelContainers.size() > 1) {
-			// if we created more than one Franca file, we use the origin file name and the
-			// franca model name as file name as we need to create multiple files and cannot
-			// use the input file with ".fidl" as extension
-			val modelName = francaModelContainer.model().getName();
-			val araFileName = transformedModelUri.lastSegment();
-			val francaFileName = araFileName + "_" + modelName;
-			transformedModelUri = transformedModelUri.trimSegments(1)
-					.appendSegment(francaFileName);
-		}
-		transformedModelUri = transformedModelUri.appendFileExtension("fidl");
+		transformedModelUri = transformedModelUri.trimSegments(1).appendSegment(francaFileName);
 		return transformedModelUri;
 	}
+
+	
 }

--- a/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/OutputFileHelper.xtend
+++ b/plugins/org.genivi.faracon.cli/src/org/genivi/faracon/cli/OutputFileHelper.xtend
@@ -10,7 +10,7 @@ class OutputFileHelper {
 	}
 
 	def static calculateFrancaOutputUri(URI araModelUri, FrancaModelContainer francaModelContainer) {
-		val francaFileName = calculateFrancaFileName(francaModelContainer.model(), araModelUri)
+		val francaFileName = calculateFrancaFileNameFromAutosarUri(araModelUri, francaModelContainer.model())
 		var transformedModelUri = araModelUri.trimFileExtension();
 		transformedModelUri = transformedModelUri.trimSegments(1).appendSegment(francaFileName);
 		return transformedModelUri;

--- a/plugins/org.genivi.faracon.eclipse.ui/xtend-gen/org/genivi/faracon/eclipse/ui/AbstractTransformationAction.java
+++ b/plugins/org.genivi.faracon.eclipse.ui/xtend-gen/org/genivi/faracon/eclipse/ui/AbstractTransformationAction.java
@@ -54,14 +54,17 @@ public abstract class AbstractTransformationAction implements IObjectActionDeleg
     this.converter = this.initConverter();
     this.logger = this.converter.getLogger();
     final Collection<IFile> relevantIFiles = this.findRelevantFilesInSelection();
-    final Function1<IFile, String> _function = (IFile it) -> {
-      try {
-        IFileStore _store = EFS.getStore(it.getLocationURI());
-        NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
-        final File file = _store.toLocalFile(0, _nullProgressMonitor);
-        return file.getAbsolutePath();
-      } catch (Throwable _e) {
-        throw Exceptions.sneakyThrow(_e);
+    final Function1<IFile, String> _function = new Function1<IFile, String>() {
+      @Override
+      public String apply(final IFile it) {
+        try {
+          IFileStore _store = EFS.getStore(it.getLocationURI());
+          NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
+          final File file = _store.toLocalFile(0, _nullProgressMonitor);
+          return file.getAbsolutePath();
+        } catch (Throwable _e) {
+          throw Exceptions.sneakyThrow(_e);
+        }
       }
     };
     final Iterable<String> filePaths = IterableExtensions.<IFile, String>map(relevantIFiles, _function);
@@ -84,8 +87,11 @@ public abstract class AbstractTransformationAction implements IObjectActionDeleg
     final StructuredSelection structuredSelection = ((StructuredSelection) this.selection);
     final List selectedElements = structuredSelection.toList();
     final HashSet<IFile> relevantFiles = CollectionLiterals.<IFile>newHashSet();
-    final Consumer<Object> _function = (Object it) -> {
-      this.findRelevantFiles(it, relevantFiles);
+    final Consumer<Object> _function = new Consumer<Object>() {
+      @Override
+      public void accept(final Object it) {
+        AbstractTransformationAction.this.findRelevantFiles(it, relevantFiles);
+      }
     };
     selectedElements.forEach(_function);
     return relevantFiles;
@@ -110,8 +116,11 @@ public abstract class AbstractTransformationAction implements IObjectActionDeleg
   
   protected void _findRelevantFiles(final IContainer iFolder, final Set<IFile> relevantFiles) {
     try {
-      final Consumer<IResource> _function = (IResource it) -> {
-        this.findRelevantFiles(it, relevantFiles);
+      final Consumer<IResource> _function = new Consumer<IResource>() {
+        @Override
+        public void accept(final IResource it) {
+          AbstractTransformationAction.this.findRelevantFiles(it, relevantFiles);
+        }
       };
       ((List<IResource>)Conversions.doWrapArray(iFolder.members())).forEach(_function);
     } catch (Throwable _e) {

--- a/plugins/org.genivi.faracon.eclipse.ui/xtend-gen/org/genivi/faracon/eclipse/ui/EclipseUiLogger.java
+++ b/plugins/org.genivi.faracon.eclipse.ui/xtend-gen/org/genivi/faracon/eclipse/ui/EclipseUiLogger.java
@@ -35,9 +35,12 @@ public class EclipseUiLogger extends AbstractLogger {
   
   private MessageConsole getConsole() {
     final IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
-    final Function1<IConsole, Boolean> _function = (IConsole it) -> {
-      String _name = it.getName();
-      return Boolean.valueOf(Objects.equal(_name, EclipseUiLogger.FARACON_CONSOLE));
+    final Function1<IConsole, Boolean> _function = new Function1<IConsole, Boolean>() {
+      @Override
+      public Boolean apply(final IConsole it) {
+        String _name = it.getName();
+        return Boolean.valueOf(Objects.equal(_name, EclipseUiLogger.FARACON_CONSOLE));
+      }
     };
     IConsole faraconConsole = IterableExtensions.<IConsole>findFirst(((Iterable<IConsole>)Conversions.doWrapArray(consoleManager.getConsoles())), _function);
     if ((null == faraconConsole)) {

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/ARAConnector.java
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/ARAConnector.java
@@ -144,6 +144,7 @@ public class ARAConnector extends BaseWithLogger implements IFrancaConnector {
 	}
 
 	public static AUTOSAR loadARAModel(String fileName) {
+		
 		ARAResourceSet araResourceSet = new ARAResourceSet();
 		return loadARAModel(araResourceSet, fileName);
 	}

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/ara2franca/Ara2FrancaUtil.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/ara2franca/Ara2FrancaUtil.xtend
@@ -1,0 +1,25 @@
+package org.genivi.faracon.ara2franca
+
+import org.eclipse.emf.common.util.URI
+import org.franca.core.franca.FModel
+
+class Ara2FrancaUtil {
+	new(){}
+	
+	/**
+	 * Calculates the Franca file name based on the autosar URI and the name of the FModel
+	 * We use the name of the input file with ".fidl" as extension and the name of the fModel
+	 * 
+	 */
+	def static String calculateFrancaFileName(FModel fModel, URI araModelUri) {
+		val modelName = fModel.name
+		return araModelUri.calculateFrancaFileNameFromAutosarFileName(modelName)
+	}
+	
+	def static String calculateFrancaFileNameFromAutosarFileName(URI araModelUri, String modelName){
+		val araFileName = araModelUri.trimFileExtension().trimFileExtension.lastSegment();
+		val francaFileName = araFileName + "_" + modelName;
+		return francaFileName + ".fidl"
+	}
+	
+}

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/ara2franca/Ara2FrancaUtil.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/ara2franca/Ara2FrancaUtil.xtend
@@ -11,13 +11,13 @@ class Ara2FrancaUtil {
 	 * We use the name of the input file with ".fidl" as extension and the name of the fModel
 	 * 
 	 */
-	def static String calculateFrancaFileName(FModel fModel, URI araModelUri) {
+	def static String calculateFrancaFileNameFromAutosarUri(URI araModelUri, FModel fModel) {
 		val modelName = fModel.name
-		return araModelUri.calculateFrancaFileNameFromAutosarFileName(modelName)
+		return araModelUri.calculateFrancaFileNameFromAutosarUri(modelName)
 	}
 	
-	def static String calculateFrancaFileNameFromAutosarFileName(URI araModelUri, String modelName){
-		val araFileName = araModelUri.trimFileExtension().trimFileExtension.lastSegment();
+	def static String calculateFrancaFileNameFromAutosarUri(URI araModelUri, String modelName){
+		val araFileName = araModelUri.trimFileExtension.lastSegment();
 		val francaFileName = araFileName + "_" + modelName;
 		return francaFileName + ".fidl"
 	}

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/ara2franca/FrancaImportCreator.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/ara2franca/FrancaImportCreator.xtend
@@ -1,0 +1,42 @@
+package org.genivi.faracon.ara2franca
+
+import autosar40.commonstructure.implementationdatatypes.ImplementationDataType
+import javax.inject.Singleton
+import org.eclipse.xtend.lib.annotations.Accessors
+import org.franca.core.franca.FModel
+import org.genivi.faracon.ARA2FrancaBase
+
+import static extension org.genivi.faracon.util.AutosarUtil.*
+
+@Singleton
+class FrancaImportCreator extends ARA2FrancaBase {
+	
+	@Accessors
+	var FModel currentModel
+	
+	def createImportIfNecessary(ImplementationDataType src){
+		if(currentModel === null){
+			logger.logError('''Cannot create import for type "«src?.shortName»". Reason: internal error: no franca model is set to be crated''')
+			return
+		}
+		val datatypePackage = src.ARPackage.packageNamespace
+		if(datatypePackage != currentModel.name){
+			// create import
+			currentModel.createAndAddImportTo(datatypePackage, src)
+		}
+		
+	}
+	
+	def private create createImport createAndAddImportTo(FModel model, String packageNameToImport, ImplementationDataType src){
+		val autosarModelUri = src?.eResource?.URI
+		if(autosarModelUri === null){
+			logger.logError('''Cannot create an import from model "«model?.name»" to package "«packageNameToImport
+			»". Reason: no file source file could be found for the implementation data type "«src»".''')
+			return 
+		}
+		val francaFileToImport = Ara2FrancaUtil.calculateFrancaFileNameFromAutosarFileName(autosarModelUri, packageNameToImport) 
+		it.importURI = francaFileToImport
+		model.imports += it
+	}
+	
+}

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/ara2franca/FrancaImportCreator.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/ara2franca/FrancaImportCreator.xtend
@@ -10,33 +10,36 @@ import static extension org.genivi.faracon.util.AutosarUtil.*
 
 @Singleton
 class FrancaImportCreator extends ARA2FrancaBase {
-	
+
 	@Accessors
 	var FModel currentModel
-	
-	def createImportIfNecessary(ImplementationDataType src){
-		if(currentModel === null){
-			logger.logError('''Cannot create import for type "«src?.shortName»". Reason: internal error: no franca model is set to be crated''')
+
+	def createImportIfNecessary(ImplementationDataType src) {
+		if (currentModel === null) {
+			logger.
+				logError('''Cannot create import for type "«src?.shortName»". Reason: internal error: no franca model is set to be create''')
 			return
 		}
 		val datatypePackage = src?.ARPackage?.packageNamespace
-		if(datatypePackage != currentModel.name){
+		if (datatypePackage != currentModel.name) {
 			// create import
-			currentModel.createAndAddImportTo(datatypePackage, src)
+			createAndAddImportToCurrentModel(datatypePackage, src)
 		}
-		
+
 	}
-	
-	def private create createImport createAndAddImportTo(FModel model, String packageNameToImport, ImplementationDataType src){
+
+	def private create createImport createAndAddImportToCurrentModel(String packageNameToImport,
+		ImplementationDataType src) {
 		val autosarModelUri = src?.eResource?.URI
-		if(autosarModelUri === null){
-			logger.logError('''Cannot create an import from model "«model?.name»" to package "«packageNameToImport
-			»". Reason: Source file for implementation data type "«src»" cannot be found.''')
-			return 
+		if (autosarModelUri === null) {
+			logger.
+				logError('''Cannot create an import from model "«currentModel?.name»" to package "«packageNameToImport»". Reason: Source file for implementation data type "«src»" cannot be found.''')
+			return
 		}
-		val francaFileToImport = Ara2FrancaUtil.calculateFrancaFileNameFromAutosarFileName(autosarModelUri, packageNameToImport) 
+		val francaFileToImport = Ara2FrancaUtil.
+			calculateFrancaFileNameFromAutosarUri(autosarModelUri, packageNameToImport)
 		it.importURI = francaFileToImport
-		model.imports += it
+		currentModel.imports += it
 	}
-	
+
 }

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/ara2franca/FrancaImportCreator.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/ara2franca/FrancaImportCreator.xtend
@@ -19,7 +19,7 @@ class FrancaImportCreator extends ARA2FrancaBase {
 			logger.logError('''Cannot create import for type "«src?.shortName»". Reason: internal error: no franca model is set to be crated''')
 			return
 		}
-		val datatypePackage = src.ARPackage.packageNamespace
+		val datatypePackage = src?.ARPackage?.packageNamespace
 		if(datatypePackage != currentModel.name){
 			// create import
 			currentModel.createAndAddImportTo(datatypePackage, src)

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/ara2franca/FrancaImportCreator.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/ara2franca/FrancaImportCreator.xtend
@@ -31,7 +31,7 @@ class FrancaImportCreator extends ARA2FrancaBase {
 		val autosarModelUri = src?.eResource?.URI
 		if(autosarModelUri === null){
 			logger.logError('''Cannot create an import from model "«model?.name»" to package "«packageNameToImport
-			»". Reason: no file source file could be found for the implementation data type "«src»".''')
+			»". Reason: Source file for implementation data type "«src»" cannot be found.''')
 			return 
 		}
 		val francaFileToImport = Ara2FrancaUtil.calculateFrancaFileNameFromAutosarFileName(autosarModelUri, packageNameToImport) 

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/util/AutosarUtil.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/util/AutosarUtil.xtend
@@ -55,4 +55,5 @@ class AutosarUtil {
 		val hierarchy = serviceInterface.namespaces.map[it.shortName]
 		return hierarchy.join(".")	
 	} 
+	
 }

--- a/tests/org.genivi.faracon.tests/META-INF/MANIFEST.MF
+++ b/tests/org.genivi.faracon.tests/META-INF/MANIFEST.MF
@@ -19,6 +19,8 @@ Require-Bundle: org.eclipse.ui,
  org.genivi.faracon;bundle-version="0.7.0",
  org.genivi.faracon.cli;bundle-version="0.7.0",
  org.junit;bundle-version="4.12.0",
- org.genivi.faracon.console;bundle-version="0.7.0"
+ org.genivi.faracon.console;bundle-version="0.7.0",
+ org.eclipse.xtext.ui;bundle-version="2.14.0",
+ org.eclipse.sphinx.emf;bundle-version="0.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_enum_level/a2f/compuMethod2EnumerationWithLimit.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_enum_level/a2f/compuMethod2EnumerationWithLimit.arxml
@@ -58,12 +58,12 @@
                       <COMPU-SCALE>
                         <SYMBOL>enumerator1</SYMBOL>
                         <LOWER-LIMIT INTERVAL-TYPE="CLOSED">1</LOWER-LIMIT>
-                		<UPPER-LIMIT INTERVAL-TYPE="CLOSED">1</UPPER-LIMIT>
+                        <UPPER-LIMIT INTERVAL-TYPE="CLOSED">1</UPPER-LIMIT>
                       </COMPU-SCALE>
                       <COMPU-SCALE>
                         <SYMBOL>enumerator2</SYMBOL>
                         <LOWER-LIMIT INTERVAL-TYPE="CLOSED">2</LOWER-LIMIT>
-                		<UPPER-LIMIT INTERVAL-TYPE="CLOSED">2</UPPER-LIMIT>
+                        <UPPER-LIMIT INTERVAL-TYPE="CLOSED">2</UPPER-LIMIT>
                       </COMPU-SCALE>
                     </COMPU-SCALES>
                   </COMPU-INTERNAL-TO-PHYS>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_file_level/a2f/IDL1110_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_file_level/a2f/IDL1110_Tests.xtend
@@ -27,6 +27,8 @@ import static extension org.genivi.faracon.tests.util.FrancaAssertHelper.*
 @InjectWith(FaraconTestsInjectorProvider)
 class IDL1110_Tests extends ARA2FrancaTestBase {
 
+	val EXPECTED_PATH = "src-gen/testcases/"
+
 	@Inject
 	var ConverterCliCommand cliCommand
 
@@ -69,7 +71,7 @@ class IDL1110_Tests extends ARA2FrancaTestBase {
 		val outputUri = OutputFileHelper.calculateFrancaOutputUri(araModelUri, fModelContainer.francaModelContainers.get(0))
 		
 		//then 
-		val expectedFrancaUri = URI.createFileURI(testPath + "testFileName.fidl")
+		val expectedFrancaUri = URI.createFileURI(testPath + "testFileName_testFranca.fidl")
 		assertEquals("Wrong franca output URI calculated", expectedFrancaUri , outputUri)
 	}
 	
@@ -101,7 +103,7 @@ class IDL1110_Tests extends ARA2FrancaTestBase {
 		cliCommand.convertARAFiles(araFilePath)
 
 		//then
-		val fModel = loader.loadModel("namespacesHierarchy")
+		val fModel = loader.loadModel(EXPECTED_PATH + "namespacesHierarchy_a1.b2.c3")
 		assertNotNull("No franca model created", fModel)
 	}
 
@@ -114,11 +116,11 @@ class IDL1110_Tests extends ARA2FrancaTestBase {
 		cliCommand.convertARAFiles(araFilePath)
 
 		//then
-		val nullFModel = loader.loadModel("multiPackagesWithContent")
+		val nullFModel = loader.loadModel(EXPECTED_PATH + "multiPackagesWithContent")
 		assertNull("The franca file with the name multiPackagesWithContent should not have been created", nullFModel)
-		val expectedFirstFrancaModel = loader.loadModel( "multiPackagesWithContent_parentPackage.firstPackageWithContent")
+		val expectedFirstFrancaModel = loader.loadModel( EXPECTED_PATH + "multiPackagesWithContent_parentPackage.firstPackageWithContent")
 		assertNotNull("No franca file with name multiPackagesWithContent_parentPackage.firstPackageWithContent created", expectedFirstFrancaModel)
-		val expectedSecondFrancaModel = loader.loadModel("multiPackagesWithContent_parentPackage.secondPackageWithContent")
+		val expectedSecondFrancaModel = loader.loadModel(EXPECTED_PATH + "multiPackagesWithContent_parentPackage.secondPackageWithContent")
 		assertNotNull("No franca file with name multiPackagesWithContent_parentPackage.secondPackageWithContent created", expectedSecondFrancaModel)
 	}
 

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_file_level/a2f/IDL1110_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_file_level/a2f/IDL1110_Tests.xtend
@@ -66,7 +66,7 @@ class IDL1110_Tests extends ARA2FrancaTestBase {
 		val fModelContainer = new FrancaMultiModelContainer(Collections.singletonList(fModel))  
 		
 		// when
-		val outputUri = OutputFileHelper.calculateFrancaOutputUri(araModelUri, fModelContainer, fModelContainer.francaModelContainers.get(0))
+		val outputUri = OutputFileHelper.calculateFrancaOutputUri(araModelUri, fModelContainer.francaModelContainers.get(0))
 		
 		//then 
 		val expectedFrancaUri = URI.createFileURI(testPath + "testFileName.fidl")
@@ -82,8 +82,8 @@ class IDL1110_Tests extends ARA2FrancaTestBase {
 		val fModelContainer = new FrancaMultiModelContainer(newArrayList(fModel1, fModel2))  
 		
 		// when
-		val francaUri1 = OutputFileHelper.calculateFrancaOutputUri(araModelUri, fModelContainer, fModelContainer.francaModelContainers.get(0))
-		val francaUri2 = OutputFileHelper.calculateFrancaOutputUri(araModelUri, fModelContainer, fModelContainer.francaModelContainers.get(1))
+		val francaUri1 = OutputFileHelper.calculateFrancaOutputUri(araModelUri, fModelContainer.francaModelContainers.get(0))
+		val francaUri2 = OutputFileHelper.calculateFrancaOutputUri(araModelUri, fModelContainer.francaModelContainers.get(1))
 		
 		//then
 		val expectedFrancaUri1 =  URI.createFileURI(testPath + "testFileName_testFranca1.fidl")

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_file_level/a2f/namespacesHierarchy.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_file_level/a2f/namespacesHierarchy.arxml
@@ -10,10 +10,10 @@
             <AR-PACKAGE UUID="1c57496d-67e2-49ab-a8b3-c63d7780dcbe">
               <SHORT-NAME>c3</SHORT-NAME>
               <ELEMENTS>
-			    <SERVICE-INTERFACE UUID="d048e623-100b-4acc-abb8-27e3381392c5">
-			      <SHORT-NAME>InterfaceWithNamespace</SHORT-NAME>
-			    </SERVICE-INTERFACE>
-			  </ELEMENTS>
+                <SERVICE-INTERFACE UUID="d048e623-100b-4acc-abb8-27e3381392c5">
+                  <SHORT-NAME>InterfaceWithNamespace</SHORT-NAME>
+                </SERVICE-INTERFACE>
+              </ELEMENTS>
             </AR-PACKAGE>
           </AR-PACKAGES>
         </AR-PACKAGE>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_franca_methods/a2f/IDL1460_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_franca_methods/a2f/IDL1460_Tests.xtend
@@ -57,7 +57,7 @@ class IDL1460_Tests extends ARA2FrancaTestBase {
 		]
 		
 		//when
-		val result = araTypeCreator.createFTypeRef(implementationDataType)
+		val result = araTypeCreator.createFTypeRefAndImport(implementationDataType)
 		
 		//then
 		result.assertNotNull

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_franca_methods/a2f/IDL1460_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_franca_methods/a2f/IDL1460_Tests.xtend
@@ -1,19 +1,21 @@
 package org.genivi.faracon.tests.aspects_on_franca_methods.a2f
 
+import javax.inject.Inject
 import org.eclipse.xtext.testing.InjectWith
 import org.franca.core.dsl.tests.util.XtextRunner2_Franca
+import org.franca.core.franca.FBasicTypeId
+import org.franca.core.franca.FModelElement
+import org.genivi.faracon.ara2franca.FrancaImportCreator
+import org.genivi.faracon.ara2franca.FrancaTypeCreator
 import org.genivi.faracon.tests.util.ARA2FrancaTestBase
 import org.genivi.faracon.tests.util.FaraconTestsInjectorProvider
 import org.junit.Test
 import org.junit.runner.RunWith
 
-import static extension org.genivi.faracon.tests.util.FaraconAssertHelper.*
-import org.franca.core.franca.FModelElement
-import static extension org.junit.Assert.assertNotNull
-import org.genivi.faracon.ara2franca.FrancaTypeCreator
-import javax.inject.Inject
-import org.franca.core.franca.FBasicTypeId
 import static org.junit.Assert.assertNull
+
+import static extension org.genivi.faracon.tests.util.FaraconAssertHelper.*
+import static extension org.junit.Assert.assertNotNull
 
 /**
  * Test mapping of Autosar-Elements to Franca-Elements
@@ -36,6 +38,7 @@ class IDL1460_Tests extends ARA2FrancaTestBase {
 	def void eventConversion() {
 		// given
 		val event = createVariableDataPrototype
+		ara2FrancaTransformation.logger.enableContinueOnErrors(true)
 		
 		//when
 		val result = ara2FrancaTransformation.transform(event)

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/IDL1125_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/IDL1125_Tests.xtend
@@ -6,6 +6,7 @@ import org.genivi.faracon.tests.util.ARA2FrancaTestBase
 import org.genivi.faracon.tests.util.FaraconTestsInjectorProvider
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.genivi.faracon.logging.AbstractLogger
 
 /**
  * Test transformation of imports from autosar to franca
@@ -37,7 +38,7 @@ class IDL1125_Tests extends ARA2FrancaTestBase {
 			testPath + "fileWithMultiImportPart2_a1.b2.c3.d4.e5.fidl"], "IDL1125_testMultipleInputToMultipleOutFiles")
 	}
 
-	@Test
+	@Test(expected = AbstractLogger.StopOnErrorException)
 	def void testSingleInputFileToMultipleFrancaFiles() {
 		transformAndCheck(testPath + "fileWithMultiImportPart1.arxml",
 			#[testPath + "fileWithMultiImport_a1.b2.c3.fidl", testPath + "fileWithMultiImport_a1.b2.c3.d4.fidl",

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/IDL1125_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/IDL1125_Tests.xtend
@@ -1,0 +1,46 @@
+package org.genivi.faracon.tests.aspects_on_import.a2f
+
+import org.eclipse.xtext.testing.InjectWith
+import org.franca.core.dsl.tests.util.XtextRunner2_Franca
+import org.genivi.faracon.tests.util.ARA2FrancaTestBase
+import org.genivi.faracon.tests.util.FaraconTestsInjectorProvider
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Test transformation of imports from autosar to franca
+ * Also includes the test for IDL1120
+ */
+@RunWith(XtextRunner2_Franca)
+@InjectWith(FaraconTestsInjectorProvider)
+class IDL1125_Tests extends ARA2FrancaTestBase {
+
+	@Test
+	def void testMultipleFilesFromAutosarWithImport() {
+		transformAndCheck(testPath + "fileWithImport.arxml",
+			#[testPath + "fileWithImport_a1.b2.c3.fidl", testPath + "fileWithImport_a1.b2.c3.d4.fidl"])
+	}
+
+	@Test
+	def void testMultipleFilesWithMultipleInterfacesAndTypesWithImport() {
+		transformAndCheck(
+			testPath + "fileWithMultiImport.arxml",
+			#[testPath + "fileWithMultiImport_a1.b2.c3.fidl", testPath + "fileWithMultiImport_a1.b2.c3.d4.fidl",
+				testPath + "fileWithMultiImport_a1.b2.c3.d4.e5.fidl"]
+		)
+	}
+
+	@Test
+	def void testMultipleInputToMultipleOutFiles() {
+		doTransformAndCheckIntegrationTest(#[testPath + "fileWithMultiImportPart1.arxml", testPath + "fileWithMultiImportPart2.arxml"],
+		#[testPath + "fileWithMultiImportPart1_a1.b2.c3.fidl", testPath + "fileWithMultiImportPart2_a1.b2.c3.d4.fidl",
+			testPath + "fileWithMultiImportPart2_a1.b2.c3.d4.e5.fidl"], "IDL1125_testMultipleInputToMultipleOutFiles")
+	}
+
+	@Test
+	def void testSingleInputFileToMultipleFrancaFiles() {
+		transformAndCheck(testPath + "fileWithMultiImportPart1.arxml",
+			#[testPath + "fileWithMultiImport_a1.b2.c3.fidl", testPath + "fileWithMultiImport_a1.b2.c3.d4.fidl",
+				testPath + "fileWithMultiImport_a1.b2.c3.d4.e5.fidl"])
+	}
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/IDL1125_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/IDL1125_Tests.xtend
@@ -33,7 +33,7 @@ class IDL1125_Tests extends ARA2FrancaTestBase {
 
 	@Test
 	def void testMultipleInputToMultipleOutFiles() {
-		doTransformAndCheckIntegrationTest(#[testPath + "fileWithMultiImportPart1.arxml", testPath + "fileWithMultiImportPart2.arxml"],
+		transformAndCheckIntegrationTest(#[testPath + "fileWithMultiImportPart1.arxml", testPath + "fileWithMultiImportPart2.arxml"],
 		#[testPath + "fileWithMultiImportPart1_a1.b2.c3.fidl", testPath + "fileWithMultiImportPart2_a1.b2.c3.d4.fidl",
 			testPath + "fileWithMultiImportPart2_a1.b2.c3.d4.e5.fidl"], "IDL1125_testMultipleInputToMultipleOutFiles")
 	}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithImport.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithImport.arxml
@@ -28,7 +28,7 @@
               </ELEMENTS>
               <AR-PACKAGES>
                 <AR-PACKAGE UUID="28165420-07df-4cd9-8378-7de4b7f1204c">
-                <SHORT-NAME>d4</SHORT-NAME>
+                  <SHORT-NAME>d4</SHORT-NAME>
                   <ELEMENTS>
                     <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
                       <SHORT-NAME>TestStruct</SHORT-NAME>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithImport.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithImport.arxml
@@ -37,13 +37,13 @@
                         <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
                           <SHORT-NAME>MyUInt32</SHORT-NAME>
                           <CATEGORY>TYPE_REFERENCE</CATEGORY>
-	                      <SW-DATA-DEF-PROPS>
-	                        <SW-DATA-DEF-PROPS-VARIANTS>
-	                          <SW-DATA-DEF-PROPS-CONDITIONAL>
-	                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
-	                          </SW-DATA-DEF-PROPS-CONDITIONAL>
-	                        </SW-DATA-DEF-PROPS-VARIANTS>
-	                      </SW-DATA-DEF-PROPS>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
                         </IMPLEMENTATION-DATA-TYPE-ELEMENT>
                       </SUB-ELEMENTS>
                     </IMPLEMENTATION-DATA-TYPE>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithImport.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithImport.arxml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AUTOSAR xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://autosar.org/schema/r4.0 http://autosar.org/schema/r4.0/autosar40/gs/gtc/arp">
+  <AR-PACKAGES>
+    <AR-PACKAGE UUID="4e700255-3163-47e4-865b-3d99c269ddcf">
+      <SHORT-NAME>a1</SHORT-NAME>
+      <AR-PACKAGES>
+        <AR-PACKAGE UUID="b2a76d30-de21-4dc1-ab04-af4472530a0b">
+          <SHORT-NAME>b2</SHORT-NAME>
+          <AR-PACKAGES>
+            <AR-PACKAGE UUID="bcc19092-5006-4069-b35e-0fad3540552f">
+              <SHORT-NAME>c3</SHORT-NAME>
+              <ELEMENTS>
+                <SERVICE-INTERFACE UUID="21d546b7-bdc8-4e75-b746-23ab69bc0291">
+                  <SHORT-NAME>ExampleInterface</SHORT-NAME>
+                  <METHODS>
+                    <CLIENT-SERVER-OPERATION UUID="9603467b-03a9-4c53-bac2-6b6f801bed31">
+                      <SHORT-NAME>exampleMethod</SHORT-NAME>
+                      <ARGUMENTS>
+                        <ARGUMENT-DATA-PROTOTYPE UUID="0197648e-b12c-46e0-a402-017fed149bad">
+                          <SHORT-NAME>testStructArg</SHORT-NAME>
+                          <TYPE-TREF DEST="IMPLEMENTATION-DATA-TYPE">/a1/b2/c3/d4/TestStruct</TYPE-TREF>
+                          <DIRECTION>IN</DIRECTION>
+                        </ARGUMENT-DATA-PROTOTYPE>
+                      </ARGUMENTS>
+                    </CLIENT-SERVER-OPERATION>
+                  </METHODS>
+                </SERVICE-INTERFACE>
+              </ELEMENTS>
+              <AR-PACKAGES>
+                <AR-PACKAGE UUID="28165420-07df-4cd9-8378-7de4b7f1204c">
+                <SHORT-NAME>d4</SHORT-NAME>
+                  <ELEMENTS>
+                    <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
+                      <SHORT-NAME>TestStruct</SHORT-NAME>
+                      <CATEGORY>STRUCTURE</CATEGORY>
+                      <SUB-ELEMENTS>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
+                          <SHORT-NAME>MyUInt32</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+	                      <SW-DATA-DEF-PROPS>
+	                        <SW-DATA-DEF-PROPS-VARIANTS>
+	                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+	                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+	                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+	                        </SW-DATA-DEF-PROPS-VARIANTS>
+	                      </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                      </SUB-ELEMENTS>
+                    </IMPLEMENTATION-DATA-TYPE>
+                  </ELEMENTS>
+                </AR-PACKAGE>
+              </AR-PACKAGES>
+            </AR-PACKAGE>
+          </AR-PACKAGES>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithImport_a1.b2.c3.d4.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithImport_a1.b2.c3.d4.fidl
@@ -1,0 +1,8 @@
+package a1.b2.c3.d4
+
+typeCollection{
+	struct TestStruct{
+		UInt32 MyUInt32
+	}
+}
+

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithImport_a1.b2.c3.d4.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithImport_a1.b2.c3.d4.fidl
@@ -1,7 +1,7 @@
 package a1.b2.c3.d4
 
-typeCollection{
-	struct TestStruct{
+typeCollection {
+	struct TestStruct {
 		UInt32 MyUInt32
 	}
 }

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithImport_a1.b2.c3.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithImport_a1.b2.c3.fidl
@@ -1,0 +1,11 @@
+package a1.b2.c3
+
+import model "fileWithImport_a1.b2.c3.d4.fidl"
+
+interface ExampleInterface{
+	method exampleMethod {
+		in {
+			a1.b2.c3.d4.TestStruct testStructArg
+		}
+	}
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport.arxml
@@ -36,28 +36,28 @@
                   </METHODS>
                 </SERVICE-INTERFACE>
                 <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
-                      <SHORT-NAME>TestStruct</SHORT-NAME>
-                      <CATEGORY>STRUCTURE</CATEGORY>
-                      <SUB-ELEMENTS>
-                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
-                          <SHORT-NAME>MyUInt8</SHORT-NAME>
-                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
-                          <SW-DATA-DEF-PROPS>
-                            <SW-DATA-DEF-PROPS-VARIANTS>
-                              <SW-DATA-DEF-PROPS-CONDITIONAL>
-                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
-                              </SW-DATA-DEF-PROPS-CONDITIONAL>
-                            </SW-DATA-DEF-PROPS-VARIANTS>
-                          </SW-DATA-DEF-PROPS>
-                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
-                      </SUB-ELEMENTS>
-                    </IMPLEMENTATION-DATA-TYPE>
+                  <SHORT-NAME>TestStruct</SHORT-NAME>
+                  <CATEGORY>STRUCTURE</CATEGORY>
+                  <SUB-ELEMENTS>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
+                      <SHORT-NAME>MyUInt8</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                  </SUB-ELEMENTS>
+                </IMPLEMENTATION-DATA-TYPE>
               </ELEMENTS>
               <AR-PACKAGES>
                 <AR-PACKAGE UUID="28165420-07df-4cd9-8378-7de4b7f1204c">
-                <SHORT-NAME>d4</SHORT-NAME>
+                  <SHORT-NAME>d4</SHORT-NAME>
                   <ELEMENTS>
-                      <SERVICE-INTERFACE UUID="21d546b7-bdc8-4e75-b746-23ab69bc0291">
+                    <SERVICE-INTERFACE UUID="21d546b7-bdc8-4e75-b746-23ab69bc0291">
                       <SHORT-NAME>ExampleInterfaceMultiImport</SHORT-NAME>
                       <METHODS>
                         <CLIENT-SERVER-OPERATION UUID="9603467b-03a9-4c53-bac2-6b6f801bed31">
@@ -91,28 +91,28 @@
                     </IMPLEMENTATION-DATA-TYPE>
                   </ELEMENTS>
                   <AR-PACKAGES>
-                      <AR-PACKAGE>
-                           <SHORT-NAME>e5</SHORT-NAME>
-                          <ELEMENTS>
-                            <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
-                              <SHORT-NAME>TestStructInE5</SHORT-NAME>
-                              <CATEGORY>STRUCTURE</CATEGORY>
-                              <SUB-ELEMENTS>
-                                <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
-                                  <SHORT-NAME>MyUInt32</SHORT-NAME>
-                                  <CATEGORY>TYPE_REFERENCE</CATEGORY>
-                                  <SW-DATA-DEF-PROPS>
-                                    <SW-DATA-DEF-PROPS-VARIANTS>
-                                      <SW-DATA-DEF-PROPS-CONDITIONAL>
-                                        <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
-                                      </SW-DATA-DEF-PROPS-CONDITIONAL>
-                                    </SW-DATA-DEF-PROPS-VARIANTS>
-                                  </SW-DATA-DEF-PROPS>
-                                </IMPLEMENTATION-DATA-TYPE-ELEMENT>
-                              </SUB-ELEMENTS>
-                            </IMPLEMENTATION-DATA-TYPE>
-                          </ELEMENTS>
-                      </AR-PACKAGE>
+                    <AR-PACKAGE>
+                      <SHORT-NAME>e5</SHORT-NAME>
+                      <ELEMENTS>
+                        <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
+                          <SHORT-NAME>TestStructInE5</SHORT-NAME>
+                          <CATEGORY>STRUCTURE</CATEGORY>
+                          <SUB-ELEMENTS>
+                            <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
+                              <SHORT-NAME>MyUInt32</SHORT-NAME>
+                              <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                              <SW-DATA-DEF-PROPS>
+                                <SW-DATA-DEF-PROPS-VARIANTS>
+                                  <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                    <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+                                  </SW-DATA-DEF-PROPS-CONDITIONAL>
+                                </SW-DATA-DEF-PROPS-VARIANTS>
+                              </SW-DATA-DEF-PROPS>
+                            </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                          </SUB-ELEMENTS>
+                        </IMPLEMENTATION-DATA-TYPE>
+                      </ELEMENTS>
+                    </AR-PACKAGE>
                   </AR-PACKAGES>
                 </AR-PACKAGE>
               </AR-PACKAGES>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport.arxml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AUTOSAR xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://autosar.org/schema/r4.0 http://autosar.org/schema/r4.0/autosar40/gs/gtc/arp">
+  <AR-PACKAGES>
+    <AR-PACKAGE UUID="4e700255-3163-47e4-865b-3d99c269ddcf">
+      <SHORT-NAME>a1</SHORT-NAME>
+      <AR-PACKAGES>
+        <AR-PACKAGE UUID="b2a76d30-de21-4dc1-ab04-af4472530a0b">
+          <SHORT-NAME>b2</SHORT-NAME>
+          <AR-PACKAGES>
+            <AR-PACKAGE UUID="bcc19092-5006-4069-b35e-0fad3540552f">
+              <SHORT-NAME>c3</SHORT-NAME>
+              <ELEMENTS>
+                <SERVICE-INTERFACE UUID="21d546b7-bdc8-4e75-b746-23ab69bc0291">
+                  <SHORT-NAME>ExampleInterface</SHORT-NAME>
+                  <METHODS>
+                    <CLIENT-SERVER-OPERATION UUID="9603467b-03a9-4c53-bac2-6b6f801bed31">
+                      <SHORT-NAME>exampleMethod</SHORT-NAME>
+                      <ARGUMENTS>
+                        <ARGUMENT-DATA-PROTOTYPE UUID="0197648e-b12c-46e0-a402-017fed149bad">
+                          <SHORT-NAME>testStructArg</SHORT-NAME>
+                          <TYPE-TREF DEST="IMPLEMENTATION-DATA-TYPE">/a1/b2/c3/TestStruct</TYPE-TREF>
+                          <DIRECTION>IN</DIRECTION>
+                        </ARGUMENT-DATA-PROTOTYPE>
+                        <ARGUMENT-DATA-PROTOTYPE UUID="0197648e-b12c-46e0-a402-017fed149bad">
+                          <SHORT-NAME>testStructInD4Arg</SHORT-NAME>
+                          <TYPE-TREF DEST="IMPLEMENTATION-DATA-TYPE">/a1/b2/c3/d4/TestStructInD4</TYPE-TREF>
+                          <DIRECTION>IN</DIRECTION>
+                        </ARGUMENT-DATA-PROTOTYPE>
+                        <ARGUMENT-DATA-PROTOTYPE UUID="0197648e-b12c-46e0-a402-017fed149bad">
+                          <SHORT-NAME>testStructInE5Arg</SHORT-NAME>
+                          <TYPE-TREF DEST="IMPLEMENTATION-DATA-TYPE">/a1/b2/c3/d4/e5/TestStructInE5</TYPE-TREF>
+                          <DIRECTION>IN</DIRECTION>
+                        </ARGUMENT-DATA-PROTOTYPE>
+                      </ARGUMENTS>
+                    </CLIENT-SERVER-OPERATION>
+                  </METHODS>
+                </SERVICE-INTERFACE>
+                <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
+                      <SHORT-NAME>TestStruct</SHORT-NAME>
+                      <CATEGORY>STRUCTURE</CATEGORY>
+                      <SUB-ELEMENTS>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
+                          <SHORT-NAME>MyUInt8</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+	                      <SW-DATA-DEF-PROPS>
+	                        <SW-DATA-DEF-PROPS-VARIANTS>
+	                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+	                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
+	                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+	                        </SW-DATA-DEF-PROPS-VARIANTS>
+	                      </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                      </SUB-ELEMENTS>
+                    </IMPLEMENTATION-DATA-TYPE>
+              </ELEMENTS>
+              <AR-PACKAGES>
+                <AR-PACKAGE UUID="28165420-07df-4cd9-8378-7de4b7f1204c">
+                <SHORT-NAME>d4</SHORT-NAME>
+                  <ELEMENTS>
+	                  <SERVICE-INTERFACE UUID="21d546b7-bdc8-4e75-b746-23ab69bc0291">
+	                  <SHORT-NAME>ExampleInterfaceMultiImport</SHORT-NAME>
+	                  <METHODS>
+	                    <CLIENT-SERVER-OPERATION UUID="9603467b-03a9-4c53-bac2-6b6f801bed31">
+	                      <SHORT-NAME>testMethod</SHORT-NAME>
+	                      <ARGUMENTS>
+	                        <ARGUMENT-DATA-PROTOTYPE UUID="0197648e-b12c-46e0-a402-017fed149bad">
+	                          <SHORT-NAME>testStructInE5Arg</SHORT-NAME>
+	                          <TYPE-TREF DEST="IMPLEMENTATION-DATA-TYPE">/a1/b2/c3/d4/e5/TestStructInE5</TYPE-TREF>
+	                          <DIRECTION>IN</DIRECTION>
+	                        </ARGUMENT-DATA-PROTOTYPE>
+	                      </ARGUMENTS>
+	                    </CLIENT-SERVER-OPERATION>
+	                  </METHODS>
+	                </SERVICE-INTERFACE>
+                    <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
+                      <SHORT-NAME>TestStructInD4</SHORT-NAME>
+                      <CATEGORY>STRUCTURE</CATEGORY>
+                      <SUB-ELEMENTS>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
+                          <SHORT-NAME>MyUInt32</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+	                      <SW-DATA-DEF-PROPS>
+	                        <SW-DATA-DEF-PROPS-VARIANTS>
+	                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+	                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+	                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+	                        </SW-DATA-DEF-PROPS-VARIANTS>
+	                      </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                      </SUB-ELEMENTS>
+                    </IMPLEMENTATION-DATA-TYPE>
+                  </ELEMENTS>
+                  <AR-PACKAGES>
+                  	<AR-PACKAGE>
+                  		 <SHORT-NAME>e5</SHORT-NAME>
+		                  <ELEMENTS>
+		                    <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
+		                      <SHORT-NAME>TestStructInE5</SHORT-NAME>
+		                      <CATEGORY>STRUCTURE</CATEGORY>
+		                      <SUB-ELEMENTS>
+		                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
+		                          <SHORT-NAME>MyUInt32</SHORT-NAME>
+		                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+			                      <SW-DATA-DEF-PROPS>
+			                        <SW-DATA-DEF-PROPS-VARIANTS>
+			                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+			                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+			                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+			                        </SW-DATA-DEF-PROPS-VARIANTS>
+			                      </SW-DATA-DEF-PROPS>
+		                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+		                      </SUB-ELEMENTS>
+		                    </IMPLEMENTATION-DATA-TYPE>
+		                  </ELEMENTS>
+                  	</AR-PACKAGE>
+                  </AR-PACKAGES>
+                </AR-PACKAGE>
+              </AR-PACKAGES>
+            </AR-PACKAGE>
+          </AR-PACKAGES>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport.arxml
@@ -42,13 +42,13 @@
                         <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
                           <SHORT-NAME>MyUInt8</SHORT-NAME>
                           <CATEGORY>TYPE_REFERENCE</CATEGORY>
-	                      <SW-DATA-DEF-PROPS>
-	                        <SW-DATA-DEF-PROPS-VARIANTS>
-	                          <SW-DATA-DEF-PROPS-CONDITIONAL>
-	                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
-	                          </SW-DATA-DEF-PROPS-CONDITIONAL>
-	                        </SW-DATA-DEF-PROPS-VARIANTS>
-	                      </SW-DATA-DEF-PROPS>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
                         </IMPLEMENTATION-DATA-TYPE-ELEMENT>
                       </SUB-ELEMENTS>
                     </IMPLEMENTATION-DATA-TYPE>
@@ -57,21 +57,21 @@
                 <AR-PACKAGE UUID="28165420-07df-4cd9-8378-7de4b7f1204c">
                 <SHORT-NAME>d4</SHORT-NAME>
                   <ELEMENTS>
-	                  <SERVICE-INTERFACE UUID="21d546b7-bdc8-4e75-b746-23ab69bc0291">
-	                  <SHORT-NAME>ExampleInterfaceMultiImport</SHORT-NAME>
-	                  <METHODS>
-	                    <CLIENT-SERVER-OPERATION UUID="9603467b-03a9-4c53-bac2-6b6f801bed31">
-	                      <SHORT-NAME>testMethod</SHORT-NAME>
-	                      <ARGUMENTS>
-	                        <ARGUMENT-DATA-PROTOTYPE UUID="0197648e-b12c-46e0-a402-017fed149bad">
-	                          <SHORT-NAME>testStructInE5Arg</SHORT-NAME>
-	                          <TYPE-TREF DEST="IMPLEMENTATION-DATA-TYPE">/a1/b2/c3/d4/e5/TestStructInE5</TYPE-TREF>
-	                          <DIRECTION>IN</DIRECTION>
-	                        </ARGUMENT-DATA-PROTOTYPE>
-	                      </ARGUMENTS>
-	                    </CLIENT-SERVER-OPERATION>
-	                  </METHODS>
-	                </SERVICE-INTERFACE>
+                      <SERVICE-INTERFACE UUID="21d546b7-bdc8-4e75-b746-23ab69bc0291">
+                      <SHORT-NAME>ExampleInterfaceMultiImport</SHORT-NAME>
+                      <METHODS>
+                        <CLIENT-SERVER-OPERATION UUID="9603467b-03a9-4c53-bac2-6b6f801bed31">
+                          <SHORT-NAME>testMethod</SHORT-NAME>
+                          <ARGUMENTS>
+                            <ARGUMENT-DATA-PROTOTYPE UUID="0197648e-b12c-46e0-a402-017fed149bad">
+                              <SHORT-NAME>testStructInE5Arg</SHORT-NAME>
+                              <TYPE-TREF DEST="IMPLEMENTATION-DATA-TYPE">/a1/b2/c3/d4/e5/TestStructInE5</TYPE-TREF>
+                              <DIRECTION>IN</DIRECTION>
+                            </ARGUMENT-DATA-PROTOTYPE>
+                          </ARGUMENTS>
+                        </CLIENT-SERVER-OPERATION>
+                      </METHODS>
+                    </SERVICE-INTERFACE>
                     <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
                       <SHORT-NAME>TestStructInD4</SHORT-NAME>
                       <CATEGORY>STRUCTURE</CATEGORY>
@@ -79,40 +79,40 @@
                         <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
                           <SHORT-NAME>MyUInt32</SHORT-NAME>
                           <CATEGORY>TYPE_REFERENCE</CATEGORY>
-	                      <SW-DATA-DEF-PROPS>
-	                        <SW-DATA-DEF-PROPS-VARIANTS>
-	                          <SW-DATA-DEF-PROPS-CONDITIONAL>
-	                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
-	                          </SW-DATA-DEF-PROPS-CONDITIONAL>
-	                        </SW-DATA-DEF-PROPS-VARIANTS>
-	                      </SW-DATA-DEF-PROPS>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
                         </IMPLEMENTATION-DATA-TYPE-ELEMENT>
                       </SUB-ELEMENTS>
                     </IMPLEMENTATION-DATA-TYPE>
                   </ELEMENTS>
                   <AR-PACKAGES>
-                  	<AR-PACKAGE>
-                  		 <SHORT-NAME>e5</SHORT-NAME>
-		                  <ELEMENTS>
-		                    <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
-		                      <SHORT-NAME>TestStructInE5</SHORT-NAME>
-		                      <CATEGORY>STRUCTURE</CATEGORY>
-		                      <SUB-ELEMENTS>
-		                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
-		                          <SHORT-NAME>MyUInt32</SHORT-NAME>
-		                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
-			                      <SW-DATA-DEF-PROPS>
-			                        <SW-DATA-DEF-PROPS-VARIANTS>
-			                          <SW-DATA-DEF-PROPS-CONDITIONAL>
-			                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
-			                          </SW-DATA-DEF-PROPS-CONDITIONAL>
-			                        </SW-DATA-DEF-PROPS-VARIANTS>
-			                      </SW-DATA-DEF-PROPS>
-		                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
-		                      </SUB-ELEMENTS>
-		                    </IMPLEMENTATION-DATA-TYPE>
-		                  </ELEMENTS>
-                  	</AR-PACKAGE>
+                      <AR-PACKAGE>
+                           <SHORT-NAME>e5</SHORT-NAME>
+                          <ELEMENTS>
+                            <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
+                              <SHORT-NAME>TestStructInE5</SHORT-NAME>
+                              <CATEGORY>STRUCTURE</CATEGORY>
+                              <SUB-ELEMENTS>
+                                <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
+                                  <SHORT-NAME>MyUInt32</SHORT-NAME>
+                                  <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                                  <SW-DATA-DEF-PROPS>
+                                    <SW-DATA-DEF-PROPS-VARIANTS>
+                                      <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                        <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+                                      </SW-DATA-DEF-PROPS-CONDITIONAL>
+                                    </SW-DATA-DEF-PROPS-VARIANTS>
+                                  </SW-DATA-DEF-PROPS>
+                                </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                              </SUB-ELEMENTS>
+                            </IMPLEMENTATION-DATA-TYPE>
+                          </ELEMENTS>
+                      </AR-PACKAGE>
                   </AR-PACKAGES>
                 </AR-PACKAGE>
               </AR-PACKAGES>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart1.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart1.arxml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AUTOSAR xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://autosar.org/schema/r4.0 http://autosar.org/schema/r4.0/autosar40/gs/gtc/arp">
+  <AR-PACKAGES>
+    <AR-PACKAGE UUID="4e700255-3163-47e4-865b-3d99c269ddcf">
+      <SHORT-NAME>a1</SHORT-NAME>
+      <AR-PACKAGES>
+        <AR-PACKAGE UUID="b2a76d30-de21-4dc1-ab04-af4472530a0b">
+          <SHORT-NAME>b2</SHORT-NAME>
+          <AR-PACKAGES>
+            <AR-PACKAGE UUID="bcc19092-5006-4069-b35e-0fad3540552f">
+              <SHORT-NAME>c3</SHORT-NAME>
+              <ELEMENTS>
+                <SERVICE-INTERFACE UUID="21d546b7-bdc8-4e75-b746-23ab69bc0291">
+                  <SHORT-NAME>ExampleInterface</SHORT-NAME>
+                  <METHODS>
+                    <CLIENT-SERVER-OPERATION UUID="9603467b-03a9-4c53-bac2-6b6f801bed31">
+                      <SHORT-NAME>exampleMethod</SHORT-NAME>
+                      <ARGUMENTS>
+                        <ARGUMENT-DATA-PROTOTYPE UUID="0197648e-b12c-46e0-a402-017fed149bad">
+                          <SHORT-NAME>testStructArg</SHORT-NAME>
+                          <TYPE-TREF DEST="IMPLEMENTATION-DATA-TYPE">/a1/b2/c3/TestStruct</TYPE-TREF>
+                          <DIRECTION>IN</DIRECTION>
+                        </ARGUMENT-DATA-PROTOTYPE>
+                        <ARGUMENT-DATA-PROTOTYPE UUID="0197648e-b12c-46e0-a402-017fed149bad">
+                          <SHORT-NAME>testStructInD4Arg</SHORT-NAME>
+                          <TYPE-TREF DEST="IMPLEMENTATION-DATA-TYPE">/a1/b2/c3/d4/TestStructInD4</TYPE-TREF>
+                          <DIRECTION>IN</DIRECTION>
+                        </ARGUMENT-DATA-PROTOTYPE>
+                        <ARGUMENT-DATA-PROTOTYPE UUID="0197648e-b12c-46e0-a402-017fed149bad">
+                          <SHORT-NAME>testStructInE5Arg</SHORT-NAME>
+                          <TYPE-TREF DEST="IMPLEMENTATION-DATA-TYPE">/a1/b2/c3/d4/e5/TestStructInE5</TYPE-TREF>
+                          <DIRECTION>IN</DIRECTION>
+                        </ARGUMENT-DATA-PROTOTYPE>
+                      </ARGUMENTS>
+                    </CLIENT-SERVER-OPERATION>
+                  </METHODS>
+                </SERVICE-INTERFACE>
+                <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
+                      <SHORT-NAME>TestStruct</SHORT-NAME>
+                      <CATEGORY>STRUCTURE</CATEGORY>
+                      <SUB-ELEMENTS>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
+                          <SHORT-NAME>MyUInt8</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+	                      <SW-DATA-DEF-PROPS>
+	                        <SW-DATA-DEF-PROPS-VARIANTS>
+	                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+	                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
+	                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+	                        </SW-DATA-DEF-PROPS-VARIANTS>
+	                      </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                      </SUB-ELEMENTS>
+                    </IMPLEMENTATION-DATA-TYPE>
+              </ELEMENTS>
+            </AR-PACKAGE>
+          </AR-PACKAGES>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart1.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart1.arxml
@@ -36,22 +36,22 @@
                   </METHODS>
                 </SERVICE-INTERFACE>
                 <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
-                      <SHORT-NAME>TestStruct</SHORT-NAME>
-                      <CATEGORY>STRUCTURE</CATEGORY>
-                      <SUB-ELEMENTS>
-                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
-                          <SHORT-NAME>MyUInt8</SHORT-NAME>
-                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
-                          <SW-DATA-DEF-PROPS>
-                            <SW-DATA-DEF-PROPS-VARIANTS>
-                              <SW-DATA-DEF-PROPS-CONDITIONAL>
-                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
-                              </SW-DATA-DEF-PROPS-CONDITIONAL>
-                            </SW-DATA-DEF-PROPS-VARIANTS>
-                          </SW-DATA-DEF-PROPS>
-                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
-                      </SUB-ELEMENTS>
-                    </IMPLEMENTATION-DATA-TYPE>
+                  <SHORT-NAME>TestStruct</SHORT-NAME>
+                  <CATEGORY>STRUCTURE</CATEGORY>
+                  <SUB-ELEMENTS>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
+                      <SHORT-NAME>MyUInt8</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                  </SUB-ELEMENTS>
+                </IMPLEMENTATION-DATA-TYPE>
               </ELEMENTS>
             </AR-PACKAGE>
           </AR-PACKAGES>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart1.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart1.arxml
@@ -42,13 +42,13 @@
                         <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
                           <SHORT-NAME>MyUInt8</SHORT-NAME>
                           <CATEGORY>TYPE_REFERENCE</CATEGORY>
-	                      <SW-DATA-DEF-PROPS>
-	                        <SW-DATA-DEF-PROPS-VARIANTS>
-	                          <SW-DATA-DEF-PROPS-CONDITIONAL>
-	                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
-	                          </SW-DATA-DEF-PROPS-CONDITIONAL>
-	                        </SW-DATA-DEF-PROPS-VARIANTS>
-	                      </SW-DATA-DEF-PROPS>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
                         </IMPLEMENTATION-DATA-TYPE-ELEMENT>
                       </SUB-ELEMENTS>
                     </IMPLEMENTATION-DATA-TYPE>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart1_a1.b2.c3.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart1_a1.b2.c3.fidl
@@ -1,0 +1,22 @@
+package a1.b2.c3
+
+import model "fileWithMultiImportPart2_a1.b2.c3.d4.fidl"
+import model "fileWithMultiImportPart2_a1.b2.c3.d4.e5.fidl"
+
+typeCollection{
+	struct TestStruct{
+		UInt8 MyUInt8
+	}
+}
+
+interface ExampleInterface{
+	method exampleMethod {
+		in {
+			TestStruct testStructArg
+			a1.b2.c3.d4.TestStructInD4 testStructInD4Arg
+			a1.b2.c3.d4.e5.TestStructInE5 testStructInE5Arg
+		}
+	}
+	
+}
+

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart1_a1.b2.c3.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart1_a1.b2.c3.fidl
@@ -3,8 +3,8 @@ package a1.b2.c3
 import model "fileWithMultiImportPart2_a1.b2.c3.d4.fidl"
 import model "fileWithMultiImportPart2_a1.b2.c3.d4.e5.fidl"
 
-typeCollection{
-	struct TestStruct{
+typeCollection {
+	struct TestStruct {
 		UInt8 MyUInt8
 	}
 }
@@ -17,6 +17,6 @@ interface ExampleInterface{
 			a1.b2.c3.d4.e5.TestStructInE5 testStructInE5Arg
 		}
 	}
-	
+
 }
 

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart2.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart2.arxml
@@ -11,9 +11,9 @@
               <SHORT-NAME>c3</SHORT-NAME>
               <AR-PACKAGES>
                 <AR-PACKAGE UUID="28165420-07df-4cd9-8378-7de4b7f1204c">
-                <SHORT-NAME>d4</SHORT-NAME>
+                  <SHORT-NAME>d4</SHORT-NAME>
                   <ELEMENTS>
-                      <SERVICE-INTERFACE UUID="21d546b7-bdc8-4e75-b746-23ab69bc0291">
+                    <SERVICE-INTERFACE UUID="21d546b7-bdc8-4e75-b746-23ab69bc0291">
                       <SHORT-NAME>ExampleInterfaceMultiImport</SHORT-NAME>
                       <METHODS>
                         <CLIENT-SERVER-OPERATION UUID="9603467b-03a9-4c53-bac2-6b6f801bed31">
@@ -47,28 +47,28 @@
                     </IMPLEMENTATION-DATA-TYPE>
                   </ELEMENTS>
                   <AR-PACKAGES>
-                      <AR-PACKAGE>
-                           <SHORT-NAME>e5</SHORT-NAME>
-                          <ELEMENTS>
-                            <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
-                              <SHORT-NAME>TestStructInE5</SHORT-NAME>
-                              <CATEGORY>STRUCTURE</CATEGORY>
-                              <SUB-ELEMENTS>
-                                <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
-                                  <SHORT-NAME>MyUInt32</SHORT-NAME>
-                                  <CATEGORY>TYPE_REFERENCE</CATEGORY>
-                                  <SW-DATA-DEF-PROPS>
-                                    <SW-DATA-DEF-PROPS-VARIANTS>
-                                      <SW-DATA-DEF-PROPS-CONDITIONAL>
-                                        <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
-                                      </SW-DATA-DEF-PROPS-CONDITIONAL>
-                                    </SW-DATA-DEF-PROPS-VARIANTS>
-                                  </SW-DATA-DEF-PROPS>
-                                </IMPLEMENTATION-DATA-TYPE-ELEMENT>
-                              </SUB-ELEMENTS>
-                            </IMPLEMENTATION-DATA-TYPE>
-                          </ELEMENTS>
-                      </AR-PACKAGE>
+                    <AR-PACKAGE>
+                      <SHORT-NAME>e5</SHORT-NAME>
+                      <ELEMENTS>
+                        <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
+                          <SHORT-NAME>TestStructInE5</SHORT-NAME>
+                          <CATEGORY>STRUCTURE</CATEGORY>
+                          <SUB-ELEMENTS>
+                            <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
+                              <SHORT-NAME>MyUInt32</SHORT-NAME>
+                              <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                              <SW-DATA-DEF-PROPS>
+                                <SW-DATA-DEF-PROPS-VARIANTS>
+                                  <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                    <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+                                  </SW-DATA-DEF-PROPS-CONDITIONAL>
+                                </SW-DATA-DEF-PROPS-VARIANTS>
+                              </SW-DATA-DEF-PROPS>
+                            </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                          </SUB-ELEMENTS>
+                        </IMPLEMENTATION-DATA-TYPE>
+                      </ELEMENTS>
+                    </AR-PACKAGE>
                   </AR-PACKAGES>
                 </AR-PACKAGE>
               </AR-PACKAGES>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart2.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart2.arxml
@@ -13,21 +13,21 @@
                 <AR-PACKAGE UUID="28165420-07df-4cd9-8378-7de4b7f1204c">
                 <SHORT-NAME>d4</SHORT-NAME>
                   <ELEMENTS>
-	                  <SERVICE-INTERFACE UUID="21d546b7-bdc8-4e75-b746-23ab69bc0291">
-	                  <SHORT-NAME>ExampleInterfaceMultiImport</SHORT-NAME>
-	                  <METHODS>
-	                    <CLIENT-SERVER-OPERATION UUID="9603467b-03a9-4c53-bac2-6b6f801bed31">
-	                      <SHORT-NAME>testMethod</SHORT-NAME>
-	                      <ARGUMENTS>
-	                        <ARGUMENT-DATA-PROTOTYPE UUID="0197648e-b12c-46e0-a402-017fed149bad">
-	                          <SHORT-NAME>testStructInE5Arg</SHORT-NAME>
-	                          <TYPE-TREF DEST="IMPLEMENTATION-DATA-TYPE">/a1/b2/c3/d4/e5/TestStructInE5</TYPE-TREF>
-	                          <DIRECTION>IN</DIRECTION>
-	                        </ARGUMENT-DATA-PROTOTYPE>
-	                      </ARGUMENTS>
-	                    </CLIENT-SERVER-OPERATION>
-	                  </METHODS>
-	                </SERVICE-INTERFACE>
+                      <SERVICE-INTERFACE UUID="21d546b7-bdc8-4e75-b746-23ab69bc0291">
+                      <SHORT-NAME>ExampleInterfaceMultiImport</SHORT-NAME>
+                      <METHODS>
+                        <CLIENT-SERVER-OPERATION UUID="9603467b-03a9-4c53-bac2-6b6f801bed31">
+                          <SHORT-NAME>testMethod</SHORT-NAME>
+                          <ARGUMENTS>
+                            <ARGUMENT-DATA-PROTOTYPE UUID="0197648e-b12c-46e0-a402-017fed149bad">
+                              <SHORT-NAME>testStructInE5Arg</SHORT-NAME>
+                              <TYPE-TREF DEST="IMPLEMENTATION-DATA-TYPE">/a1/b2/c3/d4/e5/TestStructInE5</TYPE-TREF>
+                              <DIRECTION>IN</DIRECTION>
+                            </ARGUMENT-DATA-PROTOTYPE>
+                          </ARGUMENTS>
+                        </CLIENT-SERVER-OPERATION>
+                      </METHODS>
+                    </SERVICE-INTERFACE>
                     <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
                       <SHORT-NAME>TestStructInD4</SHORT-NAME>
                       <CATEGORY>STRUCTURE</CATEGORY>
@@ -35,40 +35,40 @@
                         <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
                           <SHORT-NAME>MyUInt32</SHORT-NAME>
                           <CATEGORY>TYPE_REFERENCE</CATEGORY>
-	                      <SW-DATA-DEF-PROPS>
-	                        <SW-DATA-DEF-PROPS-VARIANTS>
-	                          <SW-DATA-DEF-PROPS-CONDITIONAL>
-	                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
-	                          </SW-DATA-DEF-PROPS-CONDITIONAL>
-	                        </SW-DATA-DEF-PROPS-VARIANTS>
-	                      </SW-DATA-DEF-PROPS>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
                         </IMPLEMENTATION-DATA-TYPE-ELEMENT>
                       </SUB-ELEMENTS>
                     </IMPLEMENTATION-DATA-TYPE>
                   </ELEMENTS>
                   <AR-PACKAGES>
-                  	<AR-PACKAGE>
-                  		 <SHORT-NAME>e5</SHORT-NAME>
-		                  <ELEMENTS>
-		                    <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
-		                      <SHORT-NAME>TestStructInE5</SHORT-NAME>
-		                      <CATEGORY>STRUCTURE</CATEGORY>
-		                      <SUB-ELEMENTS>
-		                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
-		                          <SHORT-NAME>MyUInt32</SHORT-NAME>
-		                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
-			                      <SW-DATA-DEF-PROPS>
-			                        <SW-DATA-DEF-PROPS-VARIANTS>
-			                          <SW-DATA-DEF-PROPS-CONDITIONAL>
-			                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
-			                          </SW-DATA-DEF-PROPS-CONDITIONAL>
-			                        </SW-DATA-DEF-PROPS-VARIANTS>
-			                      </SW-DATA-DEF-PROPS>
-		                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
-		                      </SUB-ELEMENTS>
-		                    </IMPLEMENTATION-DATA-TYPE>
-		                  </ELEMENTS>
-                  	</AR-PACKAGE>
+                      <AR-PACKAGE>
+                           <SHORT-NAME>e5</SHORT-NAME>
+                          <ELEMENTS>
+                            <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
+                              <SHORT-NAME>TestStructInE5</SHORT-NAME>
+                              <CATEGORY>STRUCTURE</CATEGORY>
+                              <SUB-ELEMENTS>
+                                <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
+                                  <SHORT-NAME>MyUInt32</SHORT-NAME>
+                                  <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                                  <SW-DATA-DEF-PROPS>
+                                    <SW-DATA-DEF-PROPS-VARIANTS>
+                                      <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                        <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+                                      </SW-DATA-DEF-PROPS-CONDITIONAL>
+                                    </SW-DATA-DEF-PROPS-VARIANTS>
+                                  </SW-DATA-DEF-PROPS>
+                                </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                              </SUB-ELEMENTS>
+                            </IMPLEMENTATION-DATA-TYPE>
+                          </ELEMENTS>
+                      </AR-PACKAGE>
                   </AR-PACKAGES>
                 </AR-PACKAGE>
               </AR-PACKAGES>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart2.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart2.arxml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AUTOSAR xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://autosar.org/schema/r4.0 http://autosar.org/schema/r4.0/autosar40/gs/gtc/arp">
+  <AR-PACKAGES>
+    <AR-PACKAGE UUID="4e700255-3163-47e4-865b-3d99c269ddcf">
+      <SHORT-NAME>a1</SHORT-NAME>
+      <AR-PACKAGES>
+        <AR-PACKAGE UUID="b2a76d30-de21-4dc1-ab04-af4472530a0b">
+          <SHORT-NAME>b2</SHORT-NAME>
+          <AR-PACKAGES>
+            <AR-PACKAGE UUID="bcc19092-5006-4069-b35e-0fad3540552f">
+              <SHORT-NAME>c3</SHORT-NAME>
+              <AR-PACKAGES>
+                <AR-PACKAGE UUID="28165420-07df-4cd9-8378-7de4b7f1204c">
+                <SHORT-NAME>d4</SHORT-NAME>
+                  <ELEMENTS>
+	                  <SERVICE-INTERFACE UUID="21d546b7-bdc8-4e75-b746-23ab69bc0291">
+	                  <SHORT-NAME>ExampleInterfaceMultiImport</SHORT-NAME>
+	                  <METHODS>
+	                    <CLIENT-SERVER-OPERATION UUID="9603467b-03a9-4c53-bac2-6b6f801bed31">
+	                      <SHORT-NAME>testMethod</SHORT-NAME>
+	                      <ARGUMENTS>
+	                        <ARGUMENT-DATA-PROTOTYPE UUID="0197648e-b12c-46e0-a402-017fed149bad">
+	                          <SHORT-NAME>testStructInE5Arg</SHORT-NAME>
+	                          <TYPE-TREF DEST="IMPLEMENTATION-DATA-TYPE">/a1/b2/c3/d4/e5/TestStructInE5</TYPE-TREF>
+	                          <DIRECTION>IN</DIRECTION>
+	                        </ARGUMENT-DATA-PROTOTYPE>
+	                      </ARGUMENTS>
+	                    </CLIENT-SERVER-OPERATION>
+	                  </METHODS>
+	                </SERVICE-INTERFACE>
+                    <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
+                      <SHORT-NAME>TestStructInD4</SHORT-NAME>
+                      <CATEGORY>STRUCTURE</CATEGORY>
+                      <SUB-ELEMENTS>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
+                          <SHORT-NAME>MyUInt32</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+	                      <SW-DATA-DEF-PROPS>
+	                        <SW-DATA-DEF-PROPS-VARIANTS>
+	                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+	                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+	                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+	                        </SW-DATA-DEF-PROPS-VARIANTS>
+	                      </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                      </SUB-ELEMENTS>
+                    </IMPLEMENTATION-DATA-TYPE>
+                  </ELEMENTS>
+                  <AR-PACKAGES>
+                  	<AR-PACKAGE>
+                  		 <SHORT-NAME>e5</SHORT-NAME>
+		                  <ELEMENTS>
+		                    <IMPLEMENTATION-DATA-TYPE UUID="fefaf604-30ce-45a7-946e-27a3d5f32472">
+		                      <SHORT-NAME>TestStructInE5</SHORT-NAME>
+		                      <CATEGORY>STRUCTURE</CATEGORY>
+		                      <SUB-ELEMENTS>
+		                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="dabbaeb9-3e64-4917-bf9c-b6d34cb4e792">
+		                          <SHORT-NAME>MyUInt32</SHORT-NAME>
+		                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+			                      <SW-DATA-DEF-PROPS>
+			                        <SW-DATA-DEF-PROPS-VARIANTS>
+			                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+			                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+			                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+			                        </SW-DATA-DEF-PROPS-VARIANTS>
+			                      </SW-DATA-DEF-PROPS>
+		                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+		                      </SUB-ELEMENTS>
+		                    </IMPLEMENTATION-DATA-TYPE>
+		                  </ELEMENTS>
+                  	</AR-PACKAGE>
+                  </AR-PACKAGES>
+                </AR-PACKAGE>
+              </AR-PACKAGES>
+            </AR-PACKAGE>
+          </AR-PACKAGES>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart2_a1.b2.c3.d4.e5.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart2_a1.b2.c3.d4.e5.fidl
@@ -1,0 +1,7 @@
+package a1.b2.c3.d4.e5
+
+typeCollection{
+	struct TestStructInE5{
+		UInt32 MyUInt32
+	}
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart2_a1.b2.c3.d4.e5.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart2_a1.b2.c3.d4.e5.fidl
@@ -1,7 +1,7 @@
 package a1.b2.c3.d4.e5
 
-typeCollection{
-	struct TestStructInE5{
+typeCollection {
+	struct TestStructInE5 {
 		UInt32 MyUInt32
 	}
 }

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart2_a1.b2.c3.d4.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart2_a1.b2.c3.d4.fidl
@@ -2,17 +2,17 @@ package a1.b2.c3.d4
 
 import model "fileWithMultiImportPart2_a1.b2.c3.d4.e5.fidl"
 
-typeCollection{
-	struct TestStructInD4{
+typeCollection {
+	struct TestStructInD4 {
 		UInt32 MyUInt32
 	}
 }
 
 interface ExampleInterfaceMultiImport{
- method testMethod{
- 	in {
- 		a1.b2.c3.d4.e5.TestStructInE5 testStructInE5Arg
- 	}
- }
- 	
+	method testMethod {
+		in {
+			a1.b2.c3.d4.e5.TestStructInE5 testStructInE5Arg
+		}
+	}
+
 }

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart2_a1.b2.c3.d4.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImportPart2_a1.b2.c3.d4.fidl
@@ -1,0 +1,18 @@
+package a1.b2.c3.d4
+
+import model "fileWithMultiImportPart2_a1.b2.c3.d4.e5.fidl"
+
+typeCollection{
+	struct TestStructInD4{
+		UInt32 MyUInt32
+	}
+}
+
+interface ExampleInterfaceMultiImport{
+ method testMethod{
+ 	in {
+ 		a1.b2.c3.d4.e5.TestStructInE5 testStructInE5Arg
+ 	}
+ }
+ 	
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport_a1.b2.c3.d4.e5.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport_a1.b2.c3.d4.e5.fidl
@@ -1,0 +1,7 @@
+package a1.b2.c3.d4.e5
+
+typeCollection{
+	struct TestStructInE5{
+		UInt32 MyUInt32
+	}
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport_a1.b2.c3.d4.e5.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport_a1.b2.c3.d4.e5.fidl
@@ -1,7 +1,7 @@
 package a1.b2.c3.d4.e5
 
-typeCollection{
-	struct TestStructInE5{
+typeCollection {
+	struct TestStructInE5 {
 		UInt32 MyUInt32
 	}
 }

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport_a1.b2.c3.d4.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport_a1.b2.c3.d4.fidl
@@ -3,16 +3,16 @@ package a1.b2.c3.d4
 import model "fileWithMultiImport_a1.b2.c3.d4.e5.fidl"
 
 interface ExampleInterfaceMultiImport{
- method testMethod{
- 	in {
- 		a1.b2.c3.d4.e5.TestStructInE5 testStructInE5Arg
- 	}
- }
- 	
+	method testMethod {
+		in {
+			a1.b2.c3.d4.e5.TestStructInE5 testStructInE5Arg
+		}
+	}
+
 }
 
-typeCollection{
-	struct TestStructInD4{
+typeCollection {
+	struct TestStructInD4 {
 		UInt32 MyUInt32
 	}
 }

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport_a1.b2.c3.d4.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport_a1.b2.c3.d4.fidl
@@ -1,0 +1,19 @@
+package a1.b2.c3.d4
+
+import model "fileWithMultiImport_a1.b2.c3.d4.e5.fidl"
+
+interface ExampleInterfaceMultiImport{
+ method testMethod{
+ 	in {
+ 		a1.b2.c3.d4.e5.TestStructInE5 testStructInE5Arg
+ 	}
+ }
+ 	
+}
+
+typeCollection{
+	struct TestStructInD4{
+		UInt32 MyUInt32
+	}
+}
+

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport_a1.b2.c3.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_import/a2f/fileWithMultiImport_a1.b2.c3.fidl
@@ -1,0 +1,22 @@
+package a1.b2.c3
+
+import model "fileWithMultiImport_a1.b2.c3.d4.fidl"
+import model "fileWithMultiImport_a1.b2.c3.d4.e5.fidl"
+
+typeCollection{
+	struct TestStruct{
+		UInt8 MyUInt8
+	}
+}
+
+interface ExampleInterface{
+	method exampleMethod {
+		in {
+			TestStruct testStructArg
+			a1.b2.c3.d4.TestStructInD4 testStructInD4Arg
+			a1.b2.c3.d4.e5.TestStructInE5 testStructInE5Arg
+		}
+	}
+	
+}
+

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/util/ARA2FrancaTestBase.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/util/ARA2FrancaTestBase.xtend
@@ -92,7 +92,7 @@ abstract class ARA2FrancaTestBase extends FaraconTestBase {
 		assertFrancaModelsAreEqual(francaModels, expectedModels)
 	}
 
-	protected def void doTransformAndCheckIntegrationTest(Collection<String> sourceFilePaths,
+	protected def void transformAndCheckIntegrationTest(Collection<String> sourceFilePaths,
 		Collection<String> expectedFilePaths, String outputFolderName) {
 		// given: non-null strings, which are not empty
 		assertFalse("No source file path given", sourceFilePaths.nullOrEmpty)
@@ -107,7 +107,6 @@ abstract class ARA2FrancaTestBase extends FaraconTestBase {
 			loader.loadModel(it);
 		].toList
 		val actualFrancaModelsPath = Preferences.instance.getPreference(PreferencesConstants.P_OUTPUT_DIRECTORY_PATH, null)
-		assertNotNull("no outputpath found", actualFrancaModelsPath)
 		val actualFrancaFilePaths = FilePathsHelper.findFiles(#[actualFrancaModelsPath], "fidl")
 		val actualFrancaModels = actualFrancaFilePaths.map[
 			loader.loadModel(it)
@@ -118,7 +117,7 @@ abstract class ARA2FrancaTestBase extends FaraconTestBase {
 	protected def List<FModel> transformToFranca(IModelContainer arModel) {
 		val transformationResult = ara2FrancaConverter.transformToFranca(
 			Collections.singletonList(arModel as ARAModelContainer))
-		ara2FrancaConverter.putAllFrancaModelsInOneResource(transformationResult)
+		ara2FrancaConverter.putAllFrancaModelsInOneResourceSet(transformationResult)
 		ara2FrancaConverter.saveAllFrancaModels(transformationResult)
 		val francaModels = transformationResult.map[value].map[it.francaModelContainers].flatten.map[it.model].toList
 		return francaModels

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/util/ARA2FrancaTestBase.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/util/ARA2FrancaTestBase.xtend
@@ -61,6 +61,7 @@ abstract class ARA2FrancaTestBase extends FaraconTestBase {
 			loader.loadModel(it);
 		].toList
 		val araModelContainers = ara2FrancaConverter.loadAllAraFiles(Collections.singletonList(sourceFilePath))
+		ara2FrancaConverter.resolveProxiesAndCheckRemaining
 		val arModel = (araModelContainers).get(0).model
 		transformAndCheck(arModel, expectedFrancaModels)
 	}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/util/ARA2FrancaTestBase.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/util/ARA2FrancaTestBase.xtend
@@ -15,7 +15,6 @@ import org.genivi.faracon.cli.FilePathsHelper
 import org.genivi.faracon.preferences.Preferences
 import org.genivi.faracon.preferences.PreferencesConstants
 import org.genivi.faracon.tests.FaraconTestBase
-import org.junit.After
 import org.junit.Before
 
 import static org.genivi.faracon.ARAConnector.*
@@ -34,10 +33,6 @@ abstract class ARA2FrancaTestBase extends FaraconTestBase {
 	@Before
 	def void beforeTest() {
 		Preferences.instance.setPreference(PreferencesConstants.P_OUTPUT_DIRECTORY_PATH, "src-gen/testcases")
-	}
-
-	@After
-	def void afterTest() {
 		ara2FrancaTransformation.logger.enableContinueOnErrors(false)
 	}
 

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/util/FaraconTestsInjectorProvider.java
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/util/FaraconTestsInjectorProvider.java
@@ -8,8 +8,7 @@ public class FaraconTestsInjectorProvider extends FrancaIDLTestsInjectorProvider
 
 	@Override
 	protected Injector internalCreateInjector() {
-	    Injector faraconInjector = new FaraconTestsStandaloneSetup().createInjectorAndDoEMFRegistration();
-		return faraconInjector;
+		return new FaraconTestsStandaloneSetup().createInjectorAndDoEMFRegistration();
 	}
 
 }

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/util/FaraconTestsInjectorProvider.java
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/util/FaraconTestsInjectorProvider.java
@@ -8,7 +8,8 @@ public class FaraconTestsInjectorProvider extends FrancaIDLTestsInjectorProvider
 
 	@Override
 	protected Injector internalCreateInjector() {
-	    return new FaraconTestsStandaloneSetup().createInjectorAndDoEMFRegistration();
+	    Injector faraconInjector = new FaraconTestsStandaloneSetup().createInjectorAndDoEMFRegistration();
+		return faraconInjector;
 	}
 
 }

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/util/FaraconTestsStandaloneSetup.java
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/util/FaraconTestsStandaloneSetup.java
@@ -1,17 +1,29 @@
 package org.genivi.faracon.tests.util;
 
+import org.eclipse.xtext.ui.editor.DirtyStateManager;
+import org.eclipse.xtext.ui.editor.IDirtyStateManager;
 import org.eclipse.xtext.util.Modules2;
 import org.franca.core.dsl.FrancaIDLTestsModule;
 import org.franca.core.dsl.FrancaIDLTestsStandaloneSetup;
 import org.genivi.faracon.cli.ConverterCliModule;
 import org.genivi.faracon.console.ConsoleLogger;
 
+import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Module;
 
 public class FaraconTestsStandaloneSetup extends FrancaIDLTestsStandaloneSetup {
-    @Override
+	@Override
     public Injector createInjector() {
-        return Guice.createInjector(Modules2.mixin(new ConverterCliModule(ConsoleLogger.class), new FrancaIDLTestsModule()));
+        return Guice.createInjector(Modules2.mixin(new ConverterCliModule(ConsoleLogger.class), new FrancaIDLTestsModule(), new AddtionalTestBinder()));
     }
+
+	static class AddtionalTestBinder implements Module {
+		@Override
+		public void configure(Binder binder) {
+			binder.bind(IDirtyStateManager.class).to(DirtyStateManager.class);
+
+		}
+	}
 }

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/util/FaraconTestsStandaloneSetup.java
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/util/FaraconTestsStandaloneSetup.java
@@ -16,14 +16,7 @@ import com.google.inject.Module;
 public class FaraconTestsStandaloneSetup extends FrancaIDLTestsStandaloneSetup {
 	@Override
     public Injector createInjector() {
-        return Guice.createInjector(Modules2.mixin(new ConverterCliModule(ConsoleLogger.class), new FrancaIDLTestsModule(), new AddtionalTestBinder()));
+        return Guice.createInjector(Modules2.mixin(new ConverterCliModule(ConsoleLogger.class), new FrancaIDLTestsModule()));
     }
 
-	static class AddtionalTestBinder implements Module {
-		@Override
-		public void configure(Binder binder) {
-			binder.bind(IDirtyStateManager.class).to(DirtyStateManager.class);
-
-		}
-	}
 }


### PR DESCRIPTION
The PR introduces handling of Franca Imports if multiple Franca files are created from multiple ARXML files.  Also checks whether the provideds ARXML models is complete in the sense that all References can be resolved.
- The PR introduces a refactoring of the converting logic as we now load first all files that need to be transformed and than start the transformation and then save all results. This is necessary in order to deal with input files that referencing each other.

The PR also fixes Issue #90 , because it was easy to fix during the refactoring