### PR TITLE
Feature/f2a/aspects for unions

### DIFF
--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/Franca2ARATransformation.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/Franca2ARATransformation.xtend
@@ -184,7 +184,7 @@ class Franca2ARATransformation extends Franca2ARABase {
 			)
 			artificalBroadcastStruct.category = "STRUCTURE"
 			val typeRefs = src.outArgs.map [
-				it.createImplementationDataTypeElement
+				it.createImplementationDataTypeElement(null)
 			]
 			artificalBroadcastStruct.subElements.addAll(typeRefs)
 			artificalBroadcastStruct.ARPackage = interfaceArPackage

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/Franca2ARATransformation.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/Franca2ARATransformation.xtend
@@ -2,13 +2,6 @@ package org.genivi.faracon
 
 import autosar40.commonstructure.implementationdatatypes.ImplementationDataType
 import autosar40.genericstructure.generaltemplateclasses.arpackage.ARPackage
-import autosar40.genericstructure.generaltemplateclasses.documentation.annotation.Annotation
-import autosar40.genericstructure.generaltemplateclasses.documentation.blockelements.DocumentationBlock
-import autosar40.genericstructure.generaltemplateclasses.documentation.textmodel.languagedatamodel.LLongName
-import autosar40.genericstructure.generaltemplateclasses.documentation.textmodel.languagedatamodel.LVerbatim
-import autosar40.genericstructure.generaltemplateclasses.documentation.textmodel.multilanguagedata.MultiLanguageVerbatim
-import autosar40.genericstructure.generaltemplateclasses.documentation.textmodel.multilanguagedata.MultilanguageLongName
-import autosar40.genericstructure.generaltemplateclasses.identifiable.Identifiable
 import autosar40.genericstructure.generaltemplateclasses.primitivetypes.ArgumentDirectionEnum
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -19,17 +12,18 @@ import org.franca.core.franca.FInterface
 import org.franca.core.franca.FMethod
 import org.franca.core.franca.FModel
 import org.franca.core.franca.FType
+import org.franca.core.franca.FTypeCollection
 import org.genivi.faracon.franca2ara.ARANamespaceCreator
 import org.genivi.faracon.franca2ara.ARAPackageCreator
 import org.genivi.faracon.franca2ara.ARAPrimitveTypesCreator
 import org.genivi.faracon.franca2ara.ARATypeCreator
 import org.genivi.faracon.names.FrancaNamesCollector
 import org.genivi.faracon.names.NamesHierarchy
+import org.genivi.faracon.util.AutosarAnnotator
 
 import static org.franca.core.framework.FrancaHelpers.*
 
 import static extension org.franca.core.FrancaModelExtensions.*
-import org.franca.core.franca.FTypeCollection
 
 @Singleton
 class Franca2ARATransformation extends Franca2ARABase {
@@ -42,6 +36,8 @@ class Franca2ARATransformation extends Franca2ARABase {
 	var extension ARAPackageCreator araPackageCreator
 	@Inject
 	var extension ARANamespaceCreator
+	@Inject
+	var extension AutosarAnnotator
 
 	@Inject
 	NamesHierarchy namesHierarchy
@@ -222,26 +218,6 @@ class Franca2ARATransformation extends Franca2ARABase {
 			getLogger.logError("The broadcast '" + originalParentInterface.name + "." + src.name +
 				"' cannot be properly converted because broadcast selectors are not representable in an AUTOSAR model! (IDL1400)")
 		}
-	}
-
-	def addAnnotation(Identifiable objectToAnnotate, String labelText, String annotationText) {
-		var LLongName lLongName = fac.createLLongName
-		lLongName.mixedText = labelText
-		var MultilanguageLongName multilanguageLongName = fac.createMultilanguageLongName
-		multilanguageLongName.l4s.add(lLongName)
-
-		var LVerbatim lVerbatim = fac.createLVerbatim
-		lVerbatim.mixedText = annotationText
-		var MultiLanguageVerbatim multiLanguageVerbatim = fac.createMultiLanguageVerbatim
-		multiLanguageVerbatim.l5s.add(lVerbatim)
-		var DocumentationBlock documentationBlock = fac.createDocumentationBlock
-		documentationBlock.verbatims.add(multiLanguageVerbatim)
-
-		var Annotation annotation = fac.createAnnotation
-		annotation.annotationOrigin = "faracon"
-		annotation.label = multilanguageLongName
-		annotation.annotationText = documentationBlock
-		objectToAnnotate.annotations.add(annotation)
 	}
 
 	static def String getARFullyQualifiedName(FInterface ^interface) {

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/ara2franca/FrancaTypeCreator.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/ara2franca/FrancaTypeCreator.xtend
@@ -5,6 +5,7 @@ import autosar40.commonstructure.implementationdatatypes.ImplementationDataTypeE
 import javax.inject.Inject
 import javax.inject.Singleton
 import org.franca.core.franca.FBasicTypeId
+import org.franca.core.franca.FCompoundType
 import org.genivi.faracon.ARA2FrancaBase
 
 @Singleton
@@ -20,6 +21,8 @@ class FrancaTypeCreator extends ARA2FrancaBase {
 		}
 		if (src.category == "STRUCTURE") {
 			return transformStructure(src)
+		} else if (src.category == "UNION") {
+			return transformUnion(src)
 		} else if (src.category == "ASSOCIATIVE_MAP") {
 			return transformMap(src)
 		} else if (src.category == "TYPE_REFERENCE") {
@@ -44,19 +47,30 @@ class FrancaTypeCreator extends ARA2FrancaBase {
 	}
 
 	def protected create fac.createFStructType transformStructure(ImplementationDataType src) {
-		name = src.shortName
-		if (src.subElements !== null) {
-			for (subElement : src.subElements) {
+		fillFrancaCompoundType(src, it)
+	}
+
+	def protected create fac.createFUnionType transformUnion(ImplementationDataType src) {
+		fillFrancaCompoundType(src, it)
+	}
+
+	def protected fillFrancaCompoundType(
+		ImplementationDataType aCompoundType,
+		FCompoundType fCompoundType
+	) {
+		fCompoundType.name = aCompoundType.shortName
+		if (aCompoundType.subElements !== null) {
+			for (subElement : aCompoundType.subElements) {
 				val araStructElementType = getTypeRefTargetType(subElement)
 				if (araStructElementType !== null) {
 					val field = fac.createFField => [
 						name = subElement.shortName
 						type = createFTypeRef(araStructElementType)
 					]
-					elements.add(field)
+					fCompoundType.elements.add(field)
 				} else {
 					getLogger.
-						logError('''No type for the Autosar sub-element "«subElement?.shortName»" in implementation data type "«src?.shortName»" found. Cannot create a matching franca element.''')
+						logError('''No type for the AUTOSAR sub-element "«subElement?.shortName»" in implementation data type "«aCompoundType?.shortName»" found. Cannot create a matching franca element.''')
 				}
 			}
 		}
@@ -82,8 +96,6 @@ class FrancaTypeCreator extends ARA2FrancaBase {
 				'''No property with type "«"valueType"»" is defined for element "«src.shortName»".''')
 		}
 	}
-
-	
 
 	def private create fac.createFArrayType transformArray(ImplementationDataType src) {
 		name = src.shortName

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/franca2ara/ARATypeCreator.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/franca2ara/ARATypeCreator.xtend
@@ -75,17 +75,29 @@ class ARATypeCreator extends Franca2ARABase {
 		return null
 	}
 
-	def private dispatch create fac.createImplementationDataType createDataTypeForReference( // use FCompoundType in order to deal with union and struct types (unions are treated like structs)
-	FCompoundType fStructType) {
-		fStructType.checkCompoundType
-		it.shortName = fStructType.name
-		it.category = "STRUCTURE"
-		val allElements = fStructType.flattenStructAndGetElements
+	def private dispatch create fac.createImplementationDataType createDataTypeForReference(FStructType fStructType) {
+		fillAutosarCompoundType(fStructType, "STRUCTURE", it)
+	}
+
+	def private dispatch create fac.createImplementationDataType createDataTypeForReference(FUnionType fUnionType) {
+		fillAutosarCompoundType(fUnionType, "UNION", it)
+	}
+
+	// Use 'FCompoundType' in order to deal with union and struct types in the same way.
+	def private fillAutosarCompoundType(
+		FCompoundType fCompoundType,
+		String category,
+		ImplementationDataType aCompoundType
+	) {
+		fCompoundType.checkCompoundType
+		aCompoundType.shortName = fCompoundType.name
+		aCompoundType.category = category
+		val allElements = fCompoundType.flattenCompoundTypeAndGetElements
 		val typeRefs = allElements.map [
 			it.createImplementationDataTypeElement
 		]
-		it.subElements.addAll(typeRefs)
-		it.ARPackage = fStructType.findArPackageForFrancaElement
+		aCompoundType.subElements.addAll(typeRefs)
+		aCompoundType.ARPackage = fCompoundType.findArPackageForFrancaElement
 	}
 
 	def dispatch void checkCompoundType(FCompoundType type) {
@@ -104,21 +116,21 @@ class ARATypeCreator extends Franca2ARABase {
 		// nothing to check
 	}
 
-	def dispatch Iterable<FField> flattenStructAndGetElements(FStructType fStructType) {
+	def dispatch Iterable<FField> flattenCompoundTypeAndGetElements(FStructType fStructType) {
 		val inheritSet = FrancaModelExtensions.getInheritationSet(fStructType)
 		val structTypes = inheritSet.map[it as FStructType].filterNull
 		val allElements = structTypes.map[it.elements].flatten.map[EcoreUtil.copy(it)]
 		return allElements
 	}
 
-	def dispatch Iterable<FField> flattenStructAndGetElements(FUnionType fUnionType) {
+	def dispatch Iterable<FField> flattenCompoundTypeAndGetElements(FUnionType fUnionType) {
 		val inheritSet = FrancaModelExtensions.getInheritationSet(fUnionType)
 		val fUnionTypes = inheritSet.map[it as FUnionType].filterNull
 		val allElements = fUnionTypes.map[it.elements].flatten.map[EcoreUtil.copy(it)]
 		return allElements
 	}
 
-	def dispatch Iterable<FField> flattenStructAndGetElements(FCompoundType fCompoundType) {
+	def dispatch Iterable<FField> flattenCompountTypeAndGetElements(FCompoundType fCompoundType) {
 		logger.logError("Flattening for type " + fCompoundType.class + "is not yet supported")
 		return Collections.emptyList
 	}

--- a/plugins/org.genivi.faracon/src/org/genivi/faracon/util/AutosarAnnotator.xtend
+++ b/plugins/org.genivi.faracon/src/org/genivi/faracon/util/AutosarAnnotator.xtend
@@ -1,0 +1,34 @@
+package org.genivi.faracon.util
+
+import autosar40.genericstructure.generaltemplateclasses.documentation.annotation.Annotation
+import autosar40.genericstructure.generaltemplateclasses.documentation.blockelements.DocumentationBlock
+import autosar40.genericstructure.generaltemplateclasses.documentation.textmodel.languagedatamodel.LLongName
+import autosar40.genericstructure.generaltemplateclasses.documentation.textmodel.languagedatamodel.LVerbatim
+import autosar40.genericstructure.generaltemplateclasses.documentation.textmodel.multilanguagedata.MultiLanguageVerbatim
+import autosar40.genericstructure.generaltemplateclasses.documentation.textmodel.multilanguagedata.MultilanguageLongName
+import autosar40.genericstructure.generaltemplateclasses.identifiable.Identifiable
+import org.genivi.faracon.Franca2ARABase
+
+class AutosarAnnotator extends Franca2ARABase {
+
+	def addAnnotation(Identifiable objectToAnnotate, String labelText, String annotationText) {
+		var LLongName lLongName = fac.createLLongName
+		lLongName.mixedText = labelText
+		var MultilanguageLongName multilanguageLongName = fac.createMultilanguageLongName
+		multilanguageLongName.l4s.add(lLongName)
+
+		var LVerbatim lVerbatim = fac.createLVerbatim
+		lVerbatim.mixedText = annotationText
+		var MultiLanguageVerbatim multiLanguageVerbatim = fac.createMultiLanguageVerbatim
+		multiLanguageVerbatim.l5s.add(lVerbatim)
+		var DocumentationBlock documentationBlock = fac.createDocumentationBlock
+		documentationBlock.verbatims.add(multiLanguageVerbatim)
+
+		var Annotation annotation = fac.createAnnotation
+		annotation.annotationOrigin = "faracon"
+		annotation.label = multilanguageLongName
+		annotation.annotationText = documentationBlock
+		objectToAnnotate.annotations.add(annotation)
+	}
+
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/a2f/IDL1680_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/a2f/IDL1680_Tests.xtend
@@ -1,0 +1,106 @@
+package org.genivi.faracon.tests.aspects_for_unions.a2f
+
+import com.google.inject.Inject
+import org.eclipse.xtext.testing.InjectWith
+import org.franca.core.dsl.tests.util.XtextRunner2_Franca
+import org.franca.core.franca.FBasicTypeId
+import org.franca.core.franca.FField
+import org.franca.core.franca.FUnionType
+import org.genivi.faracon.ara2franca.FrancaTypeCreator
+import org.genivi.faracon.tests.util.ARA2FrancaTestBase
+import org.genivi.faracon.tests.util.FaraconTestsInjectorProvider
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static extension org.genivi.faracon.tests.util.FaraconAssertHelper.*
+import static extension org.genivi.faracon.tests.util.FrancaAssertHelper.*
+
+/**
+ * Test transformation of Autosar implementation data type with category 
+ * UNION to Franca union type. 
+ */
+@RunWith(XtextRunner2_Franca)
+@InjectWith(FaraconTestsInjectorProvider)
+class IDL1680_Tests extends ARA2FrancaTestBase {
+
+	@Inject
+	var FrancaTypeCreator francaTypeCreator
+
+	@Test
+	def void testSimpleUnion() {
+		// given
+		val testUnionName = "TestArUnion"
+		val autosarUnion = createImplementationDataType => [
+			shortName = testUnionName
+			category = "UNION"
+		]
+
+		// when
+		val result = francaTypeCreator.transform(autosarUnion)
+
+		// then
+		result.assertIsInstanceOf(FUnionType)
+		result.assertName(testUnionName)
+	}
+
+	@Test
+	def void testUnionWithContent() {
+		// given
+		val testUnionName = "TestArUnion"
+		val subElement1 = createImplementationDataTypeElement => [
+			shortName = "MyUInt8"
+			category = "TYPE_REFERENCE"
+			swDataDefProps = createSwDataDefProps => [
+				swDataDefPropsVariants += createSwDataDefPropsConditional => [
+					it.implementationDataType = createImplementationDataType => [
+						it.category = "VALUE"
+						it.shortName = "UInt8"
+					]
+				]
+			]
+		]
+		val subElement2 = createImplementationDataTypeElement => [
+			shortName = "MyUInt16"
+			category = "TYPE_REFERENCE"
+			swDataDefProps = createSwDataDefProps => [
+				swDataDefPropsVariants += createSwDataDefPropsConditional => [
+					it.implementationDataType = createImplementationDataType => [
+						it.category = "VALUE"
+						it.shortName = "UInt16"
+					]
+				]
+			]
+		]
+		val autosarUnion = createImplementationDataType => [
+			shortName = testUnionName
+			category = "UNION"
+			subElements += subElement1
+			subElements += subElement2
+		]
+
+		// when
+		val result = francaTypeCreator.transform(autosarUnion)
+
+		// then
+		val unionType = result.assertType(FUnionType, "TestArUnion")
+		val elements = unionType.elements.assertElements(2).sortBy[name]
+		elements.get(0).assertFTypedElement(FField, "MyUInt16", false, false, FBasicTypeId.UINT16)
+		elements.get(1).assertFTypedElement(FField, "MyUInt8", false, false, FBasicTypeId.UINT8)
+	}
+	
+	@Test
+	def void testSingleUnionInArxmlFile(){
+		transformAndCheck(testPath + "singleUnionTest.arxml", testPath + "singleUnionTest.fidl")
+	}
+	
+	@Test
+	def void testMultipleUnionsInArxmlFile(){
+		transformAndCheck(testPath + "multipleUnionsTest.arxml", testPath + "multipleUnionsTest.fidl")
+	}
+	
+	@Test
+	def void testUnionAndInterfaceInArxmlFile(){
+		transformAndCheck(testPath + "unionAndInterfaceInPackageTest.arxml", testPath + "unionAndInterfaceInPackage.fidl")
+	}
+	
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/a2f/multipleUnionsTest.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/a2f/multipleUnionsTest.arxml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AUTOSAR xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://autosar.org/schema/r4.0 http://autosar.org/schema/r4.0/autosar40/atls">
+  <AR-PACKAGES>
+    <AR-PACKAGE UUID="0">
+      <SHORT-NAME>a1</SHORT-NAME>
+      <AR-PACKAGES>
+        <AR-PACKAGE UUID="0">
+          <SHORT-NAME>b2</SHORT-NAME>
+          <AR-PACKAGES>
+            <AR-PACKAGE UUID="0">
+              <SHORT-NAME>c3</SHORT-NAME>
+              <ELEMENTS>
+                <IMPLEMENTATION-DATA-TYPE UUID="0">
+                  <SHORT-NAME>TestArUnion</SHORT-NAME>
+                  <CATEGORY>UNION</CATEGORY>
+                  <SUB-ELEMENTS>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                      <SHORT-NAME>MyUInt8</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                      <SHORT-NAME>MyUInt16</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt16</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                  </SUB-ELEMENTS>
+                </IMPLEMENTATION-DATA-TYPE>
+                <IMPLEMENTATION-DATA-TYPE UUID="0">
+                  <SHORT-NAME>TestArUnion2</SHORT-NAME>
+                  <CATEGORY>UNION</CATEGORY>
+                  <SUB-ELEMENTS>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                      <SHORT-NAME>MyUInt8</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                  </SUB-ELEMENTS>
+                </IMPLEMENTATION-DATA-TYPE>
+              </ELEMENTS>
+            </AR-PACKAGE>
+          </AR-PACKAGES>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/a2f/multipleUnionsTest.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/a2f/multipleUnionsTest.fidl
@@ -1,0 +1,11 @@
+package a1.b2.c3
+
+typeCollection {
+	union TestArUnion {
+		UInt8 MyUInt8
+		UInt16 MyUInt16
+	}
+	union TestArUnion2 {
+		UInt8 MyUInt8
+	}
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/a2f/singleUnionTest.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/a2f/singleUnionTest.arxml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AUTOSAR xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://autosar.org/schema/r4.0 http://autosar.org/schema/r4.0/autosar40/atls">
+  <AR-PACKAGES>
+    <AR-PACKAGE UUID="0">
+      <SHORT-NAME>a1</SHORT-NAME>
+      <AR-PACKAGES>
+        <AR-PACKAGE UUID="0">
+          <SHORT-NAME>b2</SHORT-NAME>
+          <AR-PACKAGES>
+            <AR-PACKAGE UUID="0">
+              <SHORT-NAME>c3</SHORT-NAME>
+              <ELEMENTS>
+                <IMPLEMENTATION-DATA-TYPE UUID="0">
+                  <SHORT-NAME>TestArUnion</SHORT-NAME>
+                  <CATEGORY>UNION</CATEGORY>
+                  <SUB-ELEMENTS>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                      <SHORT-NAME>MyUInt8</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                      <SHORT-NAME>MyUInt16</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt16</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                  </SUB-ELEMENTS>
+                </IMPLEMENTATION-DATA-TYPE>
+              </ELEMENTS>
+            </AR-PACKAGE>
+          </AR-PACKAGES>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/a2f/singleUnionTest.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/a2f/singleUnionTest.fidl
@@ -1,0 +1,8 @@
+package a1.b2.c3
+
+typeCollection {
+	union TestArUnion {
+		UInt8 MyUInt8
+		UInt16 MyUInt16
+	}
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/a2f/unionAndInterfaceInPackage.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/a2f/unionAndInterfaceInPackage.fidl
@@ -1,0 +1,16 @@
+package a1.b2.c3
+
+typeCollection {
+	union TestArUnion {
+		UInt8 MyUInt8
+		UInt16 MyUInt16
+	}
+}
+
+interface TestArInterface {
+	method exampleMethod {
+		in {
+			TestArUnion testUnionInstance
+		}
+	}
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/a2f/unionAndInterfaceInPackageTest.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/a2f/unionAndInterfaceInPackageTest.arxml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AUTOSAR xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://autosar.org/schema/r4.0 http://autosar.org/schema/r4.0/autosar40/swc/components">
+  <AR-PACKAGES>
+    <AR-PACKAGE UUID="0">
+      <SHORT-NAME>a1</SHORT-NAME>
+      <AR-PACKAGES>
+        <AR-PACKAGE UUID="0">
+          <SHORT-NAME>b2</SHORT-NAME>
+          <AR-PACKAGES>
+            <AR-PACKAGE UUID="0">
+              <SHORT-NAME>c3</SHORT-NAME>
+              <ELEMENTS>
+                <SERVICE-INTERFACE UUID="0">
+                  <SHORT-NAME>TestArInterface</SHORT-NAME>
+                  <NAMESPACES>
+                    <SYMBOL-PROPS>
+                      <SHORT-NAME>a1</SHORT-NAME>
+                      <SYMBOL>a1</SYMBOL>
+                    </SYMBOL-PROPS>
+                    <SYMBOL-PROPS>
+                      <SHORT-NAME>b2</SHORT-NAME>
+                      <SYMBOL>b2</SYMBOL>
+                    </SYMBOL-PROPS>
+                    <SYMBOL-PROPS>
+                      <SHORT-NAME>c3</SHORT-NAME>
+                      <SYMBOL>c3</SYMBOL>
+                    </SYMBOL-PROPS>
+                  </NAMESPACES>
+                  <METHODS>
+                    <CLIENT-SERVER-OPERATION UUID="0">
+                      <SHORT-NAME>exampleMethod</SHORT-NAME>
+                      <ARGUMENTS>
+                        <ARGUMENT-DATA-PROTOTYPE UUID="0">
+                          <SHORT-NAME>testUnionInstance</SHORT-NAME>
+                          <TYPE-TREF DEST="IMPLEMENTATION-DATA-TYPE">/a1/b2/c3/TestArUnion</TYPE-TREF>
+                          <DIRECTION>IN</DIRECTION>
+                        </ARGUMENT-DATA-PROTOTYPE>
+                      </ARGUMENTS>
+                    </CLIENT-SERVER-OPERATION>
+                  </METHODS>
+                </SERVICE-INTERFACE>
+                <IMPLEMENTATION-DATA-TYPE UUID="0">
+                  <SHORT-NAME>TestArUnion</SHORT-NAME>
+                  <CATEGORY>UNION</CATEGORY>
+                  <SUB-ELEMENTS>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                      <SHORT-NAME>MyUInt8</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                      <SHORT-NAME>MyUInt16</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt16</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                  </SUB-ELEMENTS>
+                </IMPLEMENTATION-DATA-TYPE>
+              </ELEMENTS>
+            </AR-PACKAGE>
+          </AR-PACKAGES>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/AbstractFranca2AraUnionTest.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/AbstractFranca2AraUnionTest.xtend
@@ -1,0 +1,33 @@
+package org.genivi.faracon.tests.aspects_for_unions.f2a
+
+import javax.inject.Inject
+import org.franca.core.franca.FBasicTypeId
+import org.franca.core.franca.FUnionType
+import org.genivi.faracon.franca2ara.ARAPrimitveTypesCreator
+import org.genivi.faracon.tests.util.Franca2ARATestBase
+import org.junit.Before
+
+abstract class AbstractFranca2AraUnionTest extends Franca2ARATestBase{
+	@Inject
+	var ARAPrimitveTypesCreator primitiveTypes
+
+	@Before
+	def void beforeTest(){
+		primitiveTypes.createPrimitiveTypesPackage(null)
+	}
+	
+	protected def FUnionType createFUnion(String unionName, String subElementName, FUnionType baseUnion) {
+		createFUnionType =>[
+			it.name = unionName
+			if(baseUnion !== null){
+				it.base = baseUnion				
+			}
+			it.elements += createFField =>[
+				it.name = subElementName
+				it.type = createFTypeRef =>[
+					it.predefined = FBasicTypeId.UINT32
+				]
+			]
+		]
+	}
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/IDL1680_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/IDL1680_Tests.xtend
@@ -1,0 +1,54 @@
+package org.genivi.faracon.tests.aspects_for_unions.f2a
+
+import autosar40.commonstructure.implementationdatatypes.ImplementationDataType
+import autosar40.commonstructure.implementationdatatypes.ImplementationDataTypeElement
+import org.eclipse.xtext.testing.InjectWith
+import org.franca.core.dsl.tests.util.XtextRunner2_Franca
+import org.genivi.faracon.tests.util.FaraconTestsInjectorProvider
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static extension org.genivi.faracon.tests.util.AutosarAssertHelper.*
+import static extension org.genivi.faracon.tests.util.FaraconAssertHelper.*
+
+/**
+ * Test cases for testing the conversion of Franca unions to AUTOSAR unions.
+ */
+@RunWith(XtextRunner2_Franca)
+@InjectWith(FaraconTestsInjectorProvider)
+class IDL1680_Tests extends AbstractFranca2AraUnionTest {
+	
+	@Test
+	def void testUnitFrancaUnionToAutosarUnion() {
+		//given
+		val unionName = "TestFUnion"
+		val subElementName = "MyUInt32"
+		val fUnion = createFUnion(unionName, subElementName, null)
+		
+		//when
+		val type = araTypeCreator.getDataTypeForReference(fUnion)
+
+		//then
+		val implementationDatatype = type.assertIsInstanceOf(ImplementationDataType).assertName(unionName).assertCategory("UNION")
+		val subElement = implementationDatatype.subElements.assertOneElement.assertIsInstanceOf(ImplementationDataTypeElement).assertName(subElementName)
+		subElement.assertCategory("TYPE_REFERENCE")
+	}
+	
+	@Test
+	def void testSingleFrancaUnionToAutosarUnion() {
+		val path = "src/org/genivi/faracon/tests/aspects_for_unions/a2f/"
+		transformAndCheck(path, "singleUnionTest", path + "singleUnionTest.arxml")
+	}
+	
+	@Test
+	def void testMultipleFrancaUnionsToAutosarUnions() {
+		val path = "src/org/genivi/faracon/tests/aspects_for_unions/a2f/"
+		transformAndCheck(path, "multipleUnionsTest", path + "multipleUnionsTest.arxml")
+	}
+	
+	@Test
+	def void testUnionAndInterfaceInPackage() {
+		val path = "src/org/genivi/faracon/tests/aspects_for_unions/a2f/"
+		transformAndCheck(path, "unionAndInterfaceInPackage", path + "unionAndInterfaceInPackageTest.arxml")
+	}
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/IDL1690_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/IDL1690_Tests.xtend
@@ -51,4 +51,9 @@ class IDL1690_Tests extends AbstractFranca2AraUnionTest{
 		transformAndCheck(testPath, "unionWithBaseUnion", testPath + "unionWithBaseUnion.arxml")
 	}
 	
+	@Test
+	def void testUnionWithBaseUnionInNamedTypeCollectionToAutosarUnion(){
+		transformAndCheck(testPath, "unionWithBaseUnionInNamedTypeCollection", testPath + "unionWithBaseUnionInNamedTypeCollection.arxml")
+	}
+	
 }

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/IDL1690_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/IDL1690_Tests.xtend
@@ -1,0 +1,54 @@
+package org.genivi.faracon.tests.aspects_for_unions.f2a
+
+import autosar40.commonstructure.implementationdatatypes.ImplementationDataType
+import autosar40.commonstructure.implementationdatatypes.ImplementationDataTypeElement
+import org.eclipse.xtext.testing.InjectWith
+import org.franca.core.dsl.tests.util.XtextRunner2_Franca
+import org.franca.core.franca.FBasicTypeId
+import org.genivi.faracon.tests.util.FaraconTestsInjectorProvider
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static extension org.genivi.faracon.tests.util.AutosarAssertHelper.*
+import static extension org.genivi.faracon.tests.util.FaraconAssertHelper.*
+
+/**
+ * Test cases for flattening Franca unions with inherited base unions.
+ */
+@RunWith(XtextRunner2_Franca)
+@InjectWith(FaraconTestsInjectorProvider)
+class IDL1690_Tests extends AbstractFranca2AraUnionTest{
+	
+	@Test
+	def void testUnitFrancaUnionWithBaseUnionToAutosarUnion(){
+		//given
+		val unionName = "TestFUnion"
+		val subElementName = "MyUInt32"
+		val baseFieldName = "BaseFieldTest"
+		val baseUnion = createFUnionType =>[
+			it.name = "TestBaseUnion"
+			it.elements += createFField =>[
+				it.name = baseFieldName
+				it.type = createFTypeRef =>[
+					it.predefined = FBasicTypeId.UINT8
+				]
+			]
+		]
+		val fUnion = this.createFUnion(unionName, subElementName, baseUnion)
+		
+		//when
+		val type = araTypeCreator.getDataTypeForReference(fUnion)
+
+		//then
+		val implementationDatatype = type.assertIsInstanceOf(ImplementationDataType).assertName(unionName).assertCategory("UNION")
+		val subElements = implementationDatatype.subElements.assertElements(2).sortBy[shortName]
+		subElements.get(0).assertIsInstanceOf(ImplementationDataTypeElement).assertName(baseFieldName).assertCategory("TYPE_REFERENCE")
+		subElements.get(1).assertIsInstanceOf(ImplementationDataTypeElement).assertName(subElementName).assertCategory("TYPE_REFERENCE")
+	}
+	
+	@Test
+	def void testUnionWithBaseUnionToAutosarUnion(){
+		transformAndCheck(testPath, "unionWithBaseUnion", testPath + "unionWithBaseUnion.arxml")
+	}
+	
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/unionWithBaseUnion.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/unionWithBaseUnion.arxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<AUTOSAR xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://autosar.org/schema/r4.0 http://autosar.org/schema/r4.0/autosar40/atls">
+<AUTOSAR xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://autosar.org/schema/r4.0 http://autosar.org/schema/r4.0/autosar40/cs/idt">
   <AR-PACKAGES>
     <AR-PACKAGE UUID="0">
       <SHORT-NAME>a1</SHORT-NAME>
@@ -17,6 +17,19 @@
                     <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
                       <SHORT-NAME>baseBaseUInt64</SHORT-NAME>
                       <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <ANNOTATIONS>
+                        <ANNOTATION>
+                          <LABEL>
+                            <L-4>OriginalUnionType</L-4>
+                          </LABEL>
+                          <ANNOTATION-ORIGIN>faracon</ANNOTATION-ORIGIN>
+                          <ANNOTATION-TEXT>
+                            <VERBATIM>
+                              <L-5>/a1/b2/c3/TestBaseBaseUnion</L-5>
+                            </VERBATIM>
+                          </ANNOTATION-TEXT>
+                        </ANNOTATION>
+                      </ANNOTATIONS>
                       <SW-DATA-DEF-PROPS>
                         <SW-DATA-DEF-PROPS-VARIANTS>
                           <SW-DATA-DEF-PROPS-CONDITIONAL>
@@ -28,6 +41,19 @@
                     <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
                       <SHORT-NAME>baseUInt32</SHORT-NAME>
                       <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <ANNOTATIONS>
+                        <ANNOTATION>
+                          <LABEL>
+                            <L-4>OriginalUnionType</L-4>
+                          </LABEL>
+                          <ANNOTATION-ORIGIN>faracon</ANNOTATION-ORIGIN>
+                          <ANNOTATION-TEXT>
+                            <VERBATIM>
+                              <L-5>/a1/b2/c3/TestBaseUnion</L-5>
+                            </VERBATIM>
+                          </ANNOTATION-TEXT>
+                        </ANNOTATION>
+                      </ANNOTATIONS>
                       <SW-DATA-DEF-PROPS>
                         <SW-DATA-DEF-PROPS-VARIANTS>
                           <SW-DATA-DEF-PROPS-CONDITIONAL>
@@ -84,6 +110,19 @@
                     <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
                       <SHORT-NAME>baseBaseUInt64</SHORT-NAME>
                       <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <ANNOTATIONS>
+                        <ANNOTATION>
+                          <LABEL>
+                            <L-4>OriginalUnionType</L-4>
+                          </LABEL>
+                          <ANNOTATION-ORIGIN>faracon</ANNOTATION-ORIGIN>
+                          <ANNOTATION-TEXT>
+                            <VERBATIM>
+                              <L-5>/a1/b2/c3/TestBaseBaseUnion</L-5>
+                            </VERBATIM>
+                          </ANNOTATION-TEXT>
+                        </ANNOTATION>
+                      </ANNOTATIONS>
                       <SW-DATA-DEF-PROPS>
                         <SW-DATA-DEF-PROPS-VARIANTS>
                           <SW-DATA-DEF-PROPS-CONDITIONAL>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/unionWithBaseUnion.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/unionWithBaseUnion.arxml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AUTOSAR xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://autosar.org/schema/r4.0 http://autosar.org/schema/r4.0/autosar40/atls">
+  <AR-PACKAGES>
+    <AR-PACKAGE UUID="0">
+      <SHORT-NAME>a1</SHORT-NAME>
+      <AR-PACKAGES>
+        <AR-PACKAGE UUID="0">
+          <SHORT-NAME>b2</SHORT-NAME>
+          <AR-PACKAGES>
+            <AR-PACKAGE UUID="0">
+              <SHORT-NAME>c3</SHORT-NAME>
+              <ELEMENTS>
+                <IMPLEMENTATION-DATA-TYPE UUID="0">
+                  <SHORT-NAME>TestArUnion</SHORT-NAME>
+                  <CATEGORY>UNION</CATEGORY>
+                  <SUB-ELEMENTS>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                      <SHORT-NAME>baseBaseUInt64</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/Int32</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                      <SHORT-NAME>baseUInt32</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                      <SHORT-NAME>MyUInt8</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                      <SHORT-NAME>MyUInt16</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt16</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                  </SUB-ELEMENTS>
+                </IMPLEMENTATION-DATA-TYPE>
+                <IMPLEMENTATION-DATA-TYPE UUID="0">
+                  <SHORT-NAME>TestBaseBaseUnion</SHORT-NAME>
+                  <CATEGORY>UNION</CATEGORY>
+                  <SUB-ELEMENTS>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                      <SHORT-NAME>baseBaseUInt64</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/Int32</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                  </SUB-ELEMENTS>
+                </IMPLEMENTATION-DATA-TYPE>
+                <IMPLEMENTATION-DATA-TYPE UUID="0">
+                  <SHORT-NAME>TestBaseUnion</SHORT-NAME>
+                  <CATEGORY>UNION</CATEGORY>
+                  <SUB-ELEMENTS>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                      <SHORT-NAME>baseBaseUInt64</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/Int32</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                    <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                      <SHORT-NAME>baseUInt32</SHORT-NAME>
+                      <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <SW-DATA-DEF-PROPS>
+                        <SW-DATA-DEF-PROPS-VARIANTS>
+                          <SW-DATA-DEF-PROPS-CONDITIONAL>
+                            <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+                          </SW-DATA-DEF-PROPS-CONDITIONAL>
+                        </SW-DATA-DEF-PROPS-VARIANTS>
+                      </SW-DATA-DEF-PROPS>
+                    </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                  </SUB-ELEMENTS>
+                </IMPLEMENTATION-DATA-TYPE>
+              </ELEMENTS>
+            </AR-PACKAGE>
+          </AR-PACKAGES>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/unionWithBaseUnion.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/unionWithBaseUnion.fidl
@@ -1,0 +1,14 @@
+package a1.b2.c3
+
+typeCollection {
+	union TestBaseBaseUnion {
+		Int32 baseBaseUInt64
+	}
+	union TestBaseUnion extends TestBaseBaseUnion {
+		UInt32 baseUInt32
+	}
+	union TestArUnion extends TestBaseUnion {
+		UInt8 MyUInt8
+		UInt16 MyUInt16
+	}
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/unionWithBaseUnionInNamedTypeCollection.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/unionWithBaseUnionInNamedTypeCollection.arxml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AUTOSAR xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://autosar.org/schema/r4.0 http://autosar.org/schema/r4.0/autosar40/cs/idt">
+  <AR-PACKAGES>
+    <AR-PACKAGE UUID="0">
+      <SHORT-NAME>a1</SHORT-NAME>
+      <AR-PACKAGES>
+        <AR-PACKAGE UUID="0">
+          <SHORT-NAME>b2</SHORT-NAME>
+          <AR-PACKAGES>
+            <AR-PACKAGE UUID="0">
+              <SHORT-NAME>c3</SHORT-NAME>
+              <AR-PACKAGES>
+                <AR-PACKAGE UUID="0">
+                  <SHORT-NAME>TypeCollectionName</SHORT-NAME>
+                  <ELEMENTS>
+                    <IMPLEMENTATION-DATA-TYPE UUID="0">
+                      <SHORT-NAME>TestArUnion</SHORT-NAME>
+                      <CATEGORY>UNION</CATEGORY>
+                      <SUB-ELEMENTS>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                          <SHORT-NAME>baseBaseUInt64</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                          <ANNOTATIONS>
+                            <ANNOTATION>
+                              <LABEL>
+                                <L-4>OriginalUnionType</L-4>
+                              </LABEL>
+                              <ANNOTATION-ORIGIN>faracon</ANNOTATION-ORIGIN>
+                              <ANNOTATION-TEXT>
+                                <VERBATIM>
+                                  <L-5>/a1/b2/c3/TypeCollectionName/TestBaseBaseUnion</L-5>
+                                </VERBATIM>
+                              </ANNOTATION-TEXT>
+                            </ANNOTATION>
+                          </ANNOTATIONS>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/Int32</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                          <SHORT-NAME>baseUInt32</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                          <ANNOTATIONS>
+                            <ANNOTATION>
+                              <LABEL>
+                                <L-4>OriginalUnionType</L-4>
+                              </LABEL>
+                              <ANNOTATION-ORIGIN>faracon</ANNOTATION-ORIGIN>
+                              <ANNOTATION-TEXT>
+                                <VERBATIM>
+                                  <L-5>/a1/b2/c3/TypeCollectionName/TestBaseUnion</L-5>
+                                </VERBATIM>
+                              </ANNOTATION-TEXT>
+                            </ANNOTATION>
+                          </ANNOTATIONS>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                          <SHORT-NAME>MyUInt8</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                          <SHORT-NAME>MyUInt16</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt16</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                      </SUB-ELEMENTS>
+                    </IMPLEMENTATION-DATA-TYPE>
+                    <IMPLEMENTATION-DATA-TYPE UUID="0">
+                      <SHORT-NAME>TestBaseBaseUnion</SHORT-NAME>
+                      <CATEGORY>UNION</CATEGORY>
+                      <SUB-ELEMENTS>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                          <SHORT-NAME>baseBaseUInt64</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/Int32</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                      </SUB-ELEMENTS>
+                    </IMPLEMENTATION-DATA-TYPE>
+                    <IMPLEMENTATION-DATA-TYPE UUID="0">
+                      <SHORT-NAME>TestBaseUnion</SHORT-NAME>
+                      <CATEGORY>UNION</CATEGORY>
+                      <SUB-ELEMENTS>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                          <SHORT-NAME>baseBaseUInt64</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                          <ANNOTATIONS>
+                            <ANNOTATION>
+                              <LABEL>
+                                <L-4>OriginalUnionType</L-4>
+                              </LABEL>
+                              <ANNOTATION-ORIGIN>faracon</ANNOTATION-ORIGIN>
+                              <ANNOTATION-TEXT>
+                                <VERBATIM>
+                                  <L-5>/a1/b2/c3/TypeCollectionName/TestBaseBaseUnion</L-5>
+                                </VERBATIM>
+                              </ANNOTATION-TEXT>
+                            </ANNOTATION>
+                          </ANNOTATIONS>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/Int32</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                          <SHORT-NAME>baseUInt32</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                      </SUB-ELEMENTS>
+                    </IMPLEMENTATION-DATA-TYPE>
+                  </ELEMENTS>
+                </AR-PACKAGE>
+              </AR-PACKAGES>
+            </AR-PACKAGE>
+          </AR-PACKAGES>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/unionWithBaseUnionInNamedTypeCollection.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_for_unions/f2a/unionWithBaseUnionInNamedTypeCollection.fidl
@@ -1,0 +1,14 @@
+package a1.b2.c3
+
+typeCollection TypeCollectionName {
+	union TestBaseBaseUnion {
+		Int32 baseBaseUInt64
+	}
+	union TestBaseUnion extends TestBaseBaseUnion {
+		UInt32 baseUInt32
+	}
+	union TestArUnion extends TestBaseUnion {
+		UInt8 MyUInt8
+		UInt16 MyUInt16
+	}
+}

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_structs/f2a/IDL1660_Tests.xtend
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_structs/f2a/IDL1660_Tests.xtend
@@ -51,4 +51,9 @@ class IDL1660_Tests extends AbstractFranca2AraStructTest{
 		transformAndCheck(testPath, "structWithBaseStruct", testPath + "structWithBaseStruct.arxml")
 	}
 	
+	@Test
+	def void testStructWithBaseStructInNamedTypeCollectionToAutosarStruct(){
+		transformAndCheck(testPath, "structWithBaseStructInNamedTypeCollection", testPath + "structWithBaseStructInNamedTypeCollection.arxml")
+	}
+	
 }

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_structs/f2a/structWithBaseStruct.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_structs/f2a/structWithBaseStruct.arxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<AUTOSAR xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://autosar.org/schema/r4.0 http://autosar.org/schema/r4.0/autosar40/atls">
+<AUTOSAR xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://autosar.org/schema/r4.0 http://autosar.org/schema/r4.0/autosar40/cs/idt">
   <AR-PACKAGES>
     <AR-PACKAGE UUID="0">
       <SHORT-NAME>a1</SHORT-NAME>
@@ -17,6 +17,19 @@
                     <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
                       <SHORT-NAME>baseBaseUInt64</SHORT-NAME>
                       <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <ANNOTATIONS>
+                        <ANNOTATION>
+                          <LABEL>
+                            <L-4>OriginalStructType</L-4>
+                          </LABEL>
+                          <ANNOTATION-ORIGIN>faracon</ANNOTATION-ORIGIN>
+                          <ANNOTATION-TEXT>
+                            <VERBATIM>
+                              <L-5>/a1/b2/c3/TestBaseBaseStruct</L-5>
+                            </VERBATIM>
+                          </ANNOTATION-TEXT>
+                        </ANNOTATION>
+                      </ANNOTATIONS>
                       <SW-DATA-DEF-PROPS>
                         <SW-DATA-DEF-PROPS-VARIANTS>
                           <SW-DATA-DEF-PROPS-CONDITIONAL>
@@ -28,6 +41,19 @@
                     <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
                       <SHORT-NAME>baseUInt32</SHORT-NAME>
                       <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <ANNOTATIONS>
+                        <ANNOTATION>
+                          <LABEL>
+                            <L-4>OriginalStructType</L-4>
+                          </LABEL>
+                          <ANNOTATION-ORIGIN>faracon</ANNOTATION-ORIGIN>
+                          <ANNOTATION-TEXT>
+                            <VERBATIM>
+                              <L-5>/a1/b2/c3/TestBaseStruct</L-5>
+                            </VERBATIM>
+                          </ANNOTATION-TEXT>
+                        </ANNOTATION>
+                      </ANNOTATIONS>
                       <SW-DATA-DEF-PROPS>
                         <SW-DATA-DEF-PROPS-VARIANTS>
                           <SW-DATA-DEF-PROPS-CONDITIONAL>
@@ -84,6 +110,19 @@
                     <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
                       <SHORT-NAME>baseBaseUInt64</SHORT-NAME>
                       <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                      <ANNOTATIONS>
+                        <ANNOTATION>
+                          <LABEL>
+                            <L-4>OriginalStructType</L-4>
+                          </LABEL>
+                          <ANNOTATION-ORIGIN>faracon</ANNOTATION-ORIGIN>
+                          <ANNOTATION-TEXT>
+                            <VERBATIM>
+                              <L-5>/a1/b2/c3/TestBaseBaseStruct</L-5>
+                            </VERBATIM>
+                          </ANNOTATION-TEXT>
+                        </ANNOTATION>
+                      </ANNOTATIONS>
                       <SW-DATA-DEF-PROPS>
                         <SW-DATA-DEF-PROPS-VARIANTS>
                           <SW-DATA-DEF-PROPS-CONDITIONAL>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_structs/f2a/structWithBaseStructInNamedTypeCollection.arxml
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_structs/f2a/structWithBaseStructInNamedTypeCollection.arxml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AUTOSAR xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://autosar.org/schema/r4.0 http://autosar.org/schema/r4.0/autosar40/cs/idt">
+  <AR-PACKAGES>
+    <AR-PACKAGE UUID="0">
+      <SHORT-NAME>a1</SHORT-NAME>
+      <AR-PACKAGES>
+        <AR-PACKAGE UUID="0">
+          <SHORT-NAME>b2</SHORT-NAME>
+          <AR-PACKAGES>
+            <AR-PACKAGE UUID="0">
+              <SHORT-NAME>c3</SHORT-NAME>
+              <AR-PACKAGES>
+                <AR-PACKAGE UUID="0">
+                  <SHORT-NAME>TypeCollectionName</SHORT-NAME>
+                  <ELEMENTS>
+                    <IMPLEMENTATION-DATA-TYPE UUID="0">
+                      <SHORT-NAME>TestArStruct</SHORT-NAME>
+                      <CATEGORY>STRUCTURE</CATEGORY>
+                      <SUB-ELEMENTS>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                          <SHORT-NAME>baseBaseUInt64</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                          <ANNOTATIONS>
+                            <ANNOTATION>
+                              <LABEL>
+                                <L-4>OriginalStructType</L-4>
+                              </LABEL>
+                              <ANNOTATION-ORIGIN>faracon</ANNOTATION-ORIGIN>
+                              <ANNOTATION-TEXT>
+                                <VERBATIM>
+                                  <L-5>/a1/b2/c3/TypeCollectionName/TestBaseBaseStruct</L-5>
+                                </VERBATIM>
+                              </ANNOTATION-TEXT>
+                            </ANNOTATION>
+                          </ANNOTATIONS>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/Int32</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                          <SHORT-NAME>baseUInt32</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                          <ANNOTATIONS>
+                            <ANNOTATION>
+                              <LABEL>
+                                <L-4>OriginalStructType</L-4>
+                              </LABEL>
+                              <ANNOTATION-ORIGIN>faracon</ANNOTATION-ORIGIN>
+                              <ANNOTATION-TEXT>
+                                <VERBATIM>
+                                  <L-5>/a1/b2/c3/TypeCollectionName/TestBaseStruct</L-5>
+                                </VERBATIM>
+                              </ANNOTATION-TEXT>
+                            </ANNOTATION>
+                          </ANNOTATIONS>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                          <SHORT-NAME>MyUInt8</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt8</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                          <SHORT-NAME>MyUInt16</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt16</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                      </SUB-ELEMENTS>
+                    </IMPLEMENTATION-DATA-TYPE>
+                    <IMPLEMENTATION-DATA-TYPE UUID="0">
+                      <SHORT-NAME>TestBaseBaseStruct</SHORT-NAME>
+                      <CATEGORY>STRUCTURE</CATEGORY>
+                      <SUB-ELEMENTS>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                          <SHORT-NAME>baseBaseUInt64</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/Int32</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                      </SUB-ELEMENTS>
+                    </IMPLEMENTATION-DATA-TYPE>
+                    <IMPLEMENTATION-DATA-TYPE UUID="0">
+                      <SHORT-NAME>TestBaseStruct</SHORT-NAME>
+                      <CATEGORY>STRUCTURE</CATEGORY>
+                      <SUB-ELEMENTS>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                          <SHORT-NAME>baseBaseUInt64</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                          <ANNOTATIONS>
+                            <ANNOTATION>
+                              <LABEL>
+                                <L-4>OriginalStructType</L-4>
+                              </LABEL>
+                              <ANNOTATION-ORIGIN>faracon</ANNOTATION-ORIGIN>
+                              <ANNOTATION-TEXT>
+                                <VERBATIM>
+                                  <L-5>/a1/b2/c3/TypeCollectionName/TestBaseBaseStruct</L-5>
+                                </VERBATIM>
+                              </ANNOTATION-TEXT>
+                            </ANNOTATION>
+                          </ANNOTATIONS>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/Int32</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                        <IMPLEMENTATION-DATA-TYPE-ELEMENT UUID="0">
+                          <SHORT-NAME>baseUInt32</SHORT-NAME>
+                          <CATEGORY>TYPE_REFERENCE</CATEGORY>
+                          <SW-DATA-DEF-PROPS>
+                            <SW-DATA-DEF-PROPS-VARIANTS>
+                              <SW-DATA-DEF-PROPS-CONDITIONAL>
+                                <IMPLEMENTATION-DATA-TYPE-REF DEST="IMPLEMENTATION-DATA-TYPE">/ara/stdtypes/UInt32</IMPLEMENTATION-DATA-TYPE-REF>
+                              </SW-DATA-DEF-PROPS-CONDITIONAL>
+                            </SW-DATA-DEF-PROPS-VARIANTS>
+                          </SW-DATA-DEF-PROPS>
+                        </IMPLEMENTATION-DATA-TYPE-ELEMENT>
+                      </SUB-ELEMENTS>
+                    </IMPLEMENTATION-DATA-TYPE>
+                  </ELEMENTS>
+                </AR-PACKAGE>
+              </AR-PACKAGES>
+            </AR-PACKAGE>
+          </AR-PACKAGES>
+        </AR-PACKAGE>
+      </AR-PACKAGES>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>

--- a/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_structs/f2a/structWithBaseStructInNamedTypeCollection.fidl
+++ b/tests/org.genivi.faracon.tests/src/org/genivi/faracon/tests/aspects_on_structs/f2a/structWithBaseStructInNamedTypeCollection.fidl
@@ -1,6 +1,6 @@
 package a1.b2.c3
 
-typeCollection {
+typeCollection TypeCollectionName {
 	struct TestBaseBaseStruct {
 		Int32 baseBaseUInt64
 	}


### PR DESCRIPTION
- Encompasses implementations for the conversion of union types in both directions (issues #85 and #86).
- Furthermore, adds the missing creation of annotations for the Franca to AUTOSAR conversion of struct types with base struct types (issue #48).